### PR TITLE
[SVR-99] 블록체인 액션 서명 방식 변경

### DIFF
--- a/backend/app/Savor22b/GraphTypes/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query.cs
@@ -1,12 +1,18 @@
 namespace Savor22b.GraphTypes;
 
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Bencodex.Types;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet;
+using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Blockchain;
+using Libplanet.Crypto;
 using Libplanet.Net;
+using Libplanet.Tx;
+using Savor22b.Action;
 using Savor22b.Helpers;
 using Savor22b.Model;
 
@@ -16,10 +22,18 @@ public class Query : ObjectGraphType
         "StyleCop.CSharp.ReadabilityRules",
         "SA1118:ParameterMustNotSpanMultipleLines",
         Justification = "GraphQL docs require long lines of text.")]
+
+
+    private readonly BlockChain _blockChain;
+    private readonly Swarm _swarm;
+
     public Query(
         BlockChain blockChain,
         Swarm? swarm = null)
     {
+        _blockChain = blockChain;
+        _swarm = swarm;
+
         Field<StringGraphType>(
             "asset",
             description: "The specified address's balance in MNT.",
@@ -65,7 +79,186 @@ public class Query : ObjectGraphType
                     return recipes;
                 }
         );
+
+
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_PlaceUserHouse",
+            description: "Place User House",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<IntGraphType>>
+                {
+                    Name = "villageId",
+                    Description = "ID of the village you want to move to",
+                },
+                new QueryArgument<NonNullGraphType<IntGraphType>>
+                {
+                    Name = "x",
+                    Description = "x coordinate of the house",
+                },
+                new QueryArgument<NonNullGraphType<IntGraphType>>
+                {
+                    Name = "y",
+                    Description = "y coordinate of the house",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(ByteUtil.ParseHex(context.GetArgument<string>("publicKey")));
+
+                var action = new PlaceUserHouseAction(
+                    context.GetArgument<int>("villageId"),
+                    context.GetArgument<int>("x"),
+                    context.GetArgument<int>("y")
+                );
+
+                return getUnsignedTransactionHex(action, publicKey);
+            }
+        );
+
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_GenerateIngredient",
+            description: "Generate Ingredient",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<GuidGraphType>>
+                {
+                    Name = "seedStateId",
+                    Description = "Seed state Id (PK)",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(ByteUtil.ParseHex(context.GetArgument<string>("publicKey")));
+
+                var action = new GenerateIngredientAction(
+                    context.GetArgument<Guid>("seedStateId"),
+                    Guid.NewGuid()
+                );
+
+                return getUnsignedTransactionHex(action, publicKey);
+            }
+        );
+
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_GenerateFood",
+            description: "Generate Food",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<IntGraphType>>
+                {
+                    Name = "recipeID",
+                    Description = "Recipe ID",
+                },
+                new QueryArgument<NonNullGraphType<ListGraphType<GuidGraphType>>>
+                {
+                    Name = "refrigeratorStateIDs",
+                    Description = "refrigerator state ID list",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(ByteUtil.ParseHex(context.GetArgument<string>("publicKey")));
+
+                var action = new GenerateFoodAction(
+                    context.GetArgument<int>("recipeID"),
+                    Guid.NewGuid(),
+                    context.GetArgument<List<Guid>>("refrigeratorStateIDs")
+                );
+
+                return getUnsignedTransactionHex(action, publicKey);
+            }
+        );
+
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_UseRandomSeedItem",
+            description: "Use Random Seed Item",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<GuidGraphType>>
+                {
+                    Name = "itemStateID",
+                    Description = "item state id to use",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(ByteUtil.ParseHex(context.GetArgument<string>("publicKey")));
+
+                var action = new UseRandomSeedItemAction(
+                    Guid.NewGuid(),
+                    context.GetArgument<Guid>("itemStateID")
+                );
+
+                return getUnsignedTransactionHex(action, publicKey);
+            }
+        );
+
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_BuyCookingEquipment",
+            description: "Buy cooking equipment",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<IntGraphType>>
+                {
+                    Name = "desiredEquipmentID",
+                    Description = "Desired Equipment ID",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(ByteUtil.ParseHex(context.GetArgument<string>("publicKey")));
+
+                var action = new BuyCookingEquipmentAction(
+                    Guid.NewGuid(),
+                    context.GetArgument<int>("desiredEquipmentID")
+                );
+
+                return getUnsignedTransactionHex(action, publicKey);
+            }
+        );
     }
+
+    private string getUnsignedTransactionHex(IAction action, PublicKey publicKey)
+    {
+        Address signer = publicKey.ToAddress();
+        TxActionList txActionList = new(new[] { action });
+
+        long nonce = _blockChain.GetNextTxNonce(signer);
+
+        TxInvoice invoice = new TxInvoice(
+            genesisHash: _blockChain.Genesis.Hash,
+            actions: txActionList
+        );
+        UnsignedTx unsignedTransaction =
+                new UnsignedTx(invoice, new TxSigningMetadata(publicKey, nonce));
+
+        byte[] unsignedTransactionString = unsignedTransaction.SerializeUnsignedTx().ToArray();
+        string unsignedTransactionHex = ByteUtil.Hex(unsignedTransactionString);
+
+        return unsignedTransactionHex;
+    }
+
 
     private List<Recipe> GetRecipeList(List<RecipeReference> recipeList, List<RecipeStat> recipeStatList)
     {


### PR DESCRIPTION
- 기존은 private key를 사용자에게 전달받아 서버가 사이닝을 대신 진행했습니다
- 보안상 결함이 될 수 있어 클라이언트가 사이닝을 진행할 수 있도록 구조를 변경했습니다
- 서버가 사이닝 할 액션 데이터를 넘기면, 클라이언트가 사이닝을 진행해 stageTransaction을 진행합니다.

![image](https://github.com/not-blond-beard/Savor-22b/assets/56328777/bbc62247-b0af-492e-829a-682e3bd3ea2c)
