### PR TITLE
[SVR-74] CancelFoodAction

### DIFF
--- a/backend/app/Savor22b.Tests/Action/BuyShopItemActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/BuyShopItemActionTests.cs
@@ -37,10 +37,11 @@ public class BuyShopItemActionTests : ActionTests
             }
         );
 
-        var inventoryStateEncoded = state.GetState(SignerAddress());
-        InventoryState inventoryState = inventoryStateEncoded is Bencodex.Types.Dictionary bdict
-            ? new InventoryState(bdict)
+        var rootStateEncoded = state.GetState(SignerAddress());
+        RootState rootState = rootStateEncoded is Bencodex.Types.Dictionary bdict
+            ? new RootState(bdict)
             : throw new Exception();
+        InventoryState inventoryState = rootState.InventoryState;
 
         Assert.Equal(0, inventoryState.SeedStateList.Count);
         Assert.Equal(0, inventoryState.RefrigeratorStateList.Count);

--- a/backend/app/Savor22b.Tests/Action/CancelFoodActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/CancelFoodActionTests.cs
@@ -1,0 +1,163 @@
+namespace Savor22b.Tests.Action;
+
+using System;
+using System.Collections.Immutable;
+using Libplanet.State;
+using Savor22b.Action;
+using Savor22b.Action.Exceptions;
+using Savor22b.States;
+using Xunit;
+
+public class CancelFoodActionTests : ActionTests
+{
+    private (
+        KitchenEquipmentState,
+        KitchenEquipmentState,
+        RefrigeratorState,
+        RootState
+    ) createPreset(int blockIndex)
+    {
+        var equipmentStateId1 = Guid.NewGuid();
+        var equipmentStateId2 = Guid.NewGuid();
+
+        var kitchenEquipmentState1 = new KitchenEquipmentState(equipmentStateId1, 1, 1, 1, 10);
+        var kitchenEquipmentState2 = new KitchenEquipmentState(equipmentStateId2, 2, 2, 1, 10);
+
+        var testFood = RefrigeratorState.CreateFood(
+            Guid.NewGuid(),
+            1,
+            "A",
+            1,
+            1,
+            1,
+            1,
+            blockIndex + 5,
+            ImmutableList<Guid>.Empty.Add(equipmentStateId1).Add(equipmentStateId2)
+        );
+
+        InventoryState beforeInventoryState = new InventoryState();
+        beforeInventoryState = beforeInventoryState.AddRefrigeratorItem(testFood);
+        beforeInventoryState = beforeInventoryState.AddKitchenEquipmentItem(kitchenEquipmentState1);
+        beforeInventoryState = beforeInventoryState.AddKitchenEquipmentItem(kitchenEquipmentState2);
+
+        KitchenState beforeKitchenState = new KitchenState();
+        beforeKitchenState.InstallKitchenEquipment(kitchenEquipmentState2, 1);
+
+        RootState beforeRootState = new RootState(
+            beforeInventoryState,
+            new VillageState(new HouseState(1, 1, 1, beforeKitchenState))
+        );
+
+        return (kitchenEquipmentState1, kitchenEquipmentState2, testFood, beforeRootState);
+    }
+
+    [Fact]
+    public void Execute_Success_Normal()
+    {
+        var blockIndex = 1;
+        IAccountStateDelta beforeState = new DummyState();
+
+        var (kitchenEquipmentState1, kitchenEquipmentState2, testFood, beforeRootState) =
+            createPreset(blockIndex);
+
+        beforeState = beforeState.SetState(SignerAddress(), beforeRootState.Serialize());
+
+        var action = new CancelFoodAction(testFood.StateID);
+
+        var afterState = action.Execute(
+            new DummyActionContext
+            {
+                PreviousStates = beforeState,
+                Signer = SignerAddress(),
+                Random = random,
+                Rehearsal = false,
+                BlockIndex = blockIndex,
+            }
+        );
+
+        var afterRootStateEncoded = afterState.GetState(SignerAddress());
+        RootState afterRootState = afterRootStateEncoded is Bencodex.Types.Dictionary bdict
+            ? new RootState(bdict)
+            : throw new Exception();
+
+        Assert.Null(afterRootState.InventoryState.GetRefrigeratorItem(testFood.StateID));
+
+        Assert.NotNull(
+            afterRootState.InventoryState.GetKitchenEquipmentState(kitchenEquipmentState1.StateID)
+        );
+        Assert.False(
+            afterRootState.InventoryState
+                .GetKitchenEquipmentState(kitchenEquipmentState1.StateID)!
+                .IsInUse(blockIndex)
+        );
+
+        Assert.NotNull(
+            afterRootState.VillageState!.HouseState.KitchenState
+                .GetApplianceSpaceStateByNumber(1)
+                .InstalledKitchenEquipmentStateId
+        );
+        Assert.False(
+            afterRootState.VillageState!.HouseState.KitchenState
+                .GetApplianceSpaceStateByNumber(1)
+                .IsInUse(blockIndex)
+        );
+    }
+
+    [Fact]
+    public void Execute_Failure_NotCooking()
+    {
+        var blockIndex = 15;
+
+        IAccountStateDelta beforeState = new DummyState();
+
+        var (kitchenEquipmentState1, kitchenEquipmentState2, testFood, beforeRootState) =
+            createPreset(blockIndex - 10);
+
+        beforeState = beforeState.SetState(SignerAddress(), beforeRootState.Serialize());
+
+        var action = new CancelFoodAction(testFood.StateID);
+
+        Assert.Throws<NotCookingException>(() =>
+        {
+            action.Execute(
+                new DummyActionContext
+                {
+                    PreviousStates = beforeState,
+                    Signer = SignerAddress(),
+                    Random = random,
+                    Rehearsal = false,
+                    BlockIndex = blockIndex,
+                }
+            );
+        });
+    }
+
+    [Fact]
+    public void Execute_Failure_NotFoundFood()
+    {
+        var blockIndex = 10;
+
+        IAccountStateDelta beforeState = new DummyState();
+
+        var (kitchenEquipmentState1, kitchenEquipmentState2, testFood, beforeRootState) =
+            createPreset(blockIndex);
+
+        beforeState = beforeState.SetState(SignerAddress(), beforeRootState.Serialize());
+
+        var action = new CancelFoodAction(Guid.NewGuid());
+
+        Assert.Throws<NotFoundDataException>(() =>
+        {
+            action.Execute(
+                new DummyActionContext
+                {
+                    PreviousStates = beforeState,
+                    Signer = SignerAddress(),
+                    Random = random,
+                    Rehearsal = false,
+                    BlockIndex = blockIndex,
+                }
+            );
+        });
+    }
+}

--- a/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
@@ -265,6 +265,10 @@ public class CreateFoodActionTests : ActionTests
                 beforeRootState.InventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId),
                 afterInventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId)
             );
+            Assert.Equal(
+                recipe.ResultFoodID,
+                afterInventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId)!.CookingFoodId
+            );
             Assert.True(
                 afterInventoryState
                     .GetKitchenEquipmentState(kitchenEquipmentStateId)!
@@ -290,6 +294,12 @@ public class CreateFoodActionTests : ActionTests
                 rootState.VillageState!.HouseState.KitchenState.GetApplianceSpaceStateByNumber(
                     spaceNumber
                 )
+            );
+            Assert.Equal(
+                recipe.ResultFoodID,
+                rootState.VillageState!.HouseState.KitchenState
+                    .GetApplianceSpaceStateByNumber(spaceNumber)
+                    .CookingFoodId
             );
             Assert.True(
                 rootState.VillageState!.HouseState.KitchenState

--- a/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
@@ -265,10 +265,6 @@ public class CreateFoodActionTests : ActionTests
                 beforeRootState.InventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId),
                 afterInventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId)
             );
-            Assert.Equal(
-                recipe.ResultFoodID,
-                afterInventoryState.GetKitchenEquipmentState(kitchenEquipmentStateId)!.CookingFoodId
-            );
             Assert.True(
                 afterInventoryState
                     .GetKitchenEquipmentState(kitchenEquipmentStateId)!
@@ -294,12 +290,6 @@ public class CreateFoodActionTests : ActionTests
                 rootState.VillageState!.HouseState.KitchenState.GetApplianceSpaceStateByNumber(
                     spaceNumber
                 )
-            );
-            Assert.Equal(
-                recipe.ResultFoodID,
-                rootState.VillageState!.HouseState.KitchenState
-                    .GetApplianceSpaceStateByNumber(spaceNumber)
-                    .CookingFoodId
             );
             Assert.True(
                 rootState.VillageState!.HouseState.KitchenState

--- a/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/CreateFoodActionTests.cs
@@ -97,7 +97,17 @@ public class CreateFoodActionTests : ActionTests
         foreach (var foodID in FoodIDList)
         {
             RefrigeratorItemList.Add(
-                RefrigeratorState.CreateFood(Guid.NewGuid(), foodID, "D", 1, 1, 1, 1, 1)
+                RefrigeratorState.CreateFood(
+                    Guid.NewGuid(),
+                    foodID,
+                    "D",
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    ImmutableList<Guid>.Empty
+                )
             );
         }
 
@@ -215,7 +225,8 @@ public class CreateFoodActionTests : ActionTests
             sameIdEdibleOrigin.DEF,
             sameIdEdibleOrigin.ATK,
             sameIdEdibleOrigin.SPD,
-            sameIdEdibleOrigin.AvailableBlockIndex
+            sameIdEdibleOrigin.AvailableBlockIndex,
+            sameIdEdibleOrigin.UsedKitchenEquipmentStateIds
         );
         beforeRootState.SetInventoryState(
             beforeRootState.InventoryState.AddRefrigeratorItem(sameIdEdible)
@@ -276,8 +287,17 @@ public class CreateFoodActionTests : ActionTests
                     .IsInUse(blockIndex + recipe.RequiredBlock)
             );
         }
+
+        ImmutableList<Guid> installedKitchenEquipmentStateIdsToUse = ImmutableList<Guid>.Empty;
         foreach (var spaceNumber in spaceNumbersToUse)
         {
+            var installedKitchenEquipmentStateId = rootState.VillageState!.HouseState.KitchenState
+                .GetApplianceSpaceStateByNumber(spaceNumber)
+                .InstalledKitchenEquipmentStateId;
+            installedKitchenEquipmentStateIdsToUse = installedKitchenEquipmentStateIdsToUse.Add(
+                installedKitchenEquipmentStateId!.Value
+            );
+
             Assert.NotNull(
                 rootState.VillageState!.HouseState.KitchenState.GetApplianceSpaceStateByNumber(
                     spaceNumber
@@ -302,6 +322,13 @@ public class CreateFoodActionTests : ActionTests
                     .IsInUse(blockIndex + recipe.RequiredBlock)
             );
         }
+
+        Assert.Equal(
+            kitchenEquipmentStateIdsToUse
+                .ToImmutableList()
+                .Concat(installedKitchenEquipmentStateIdsToUse),
+            afterInventoryState.GetRefrigeratorItem(newFoodGuid)!.UsedKitchenEquipmentStateIds
+        );
     }
 
     [Fact]
@@ -375,7 +402,6 @@ public class CreateFoodActionTests : ActionTests
                     spaceNumber
                 )
             );
-
             Assert.True(
                 afterRootState.VillageState!.HouseState.KitchenState
                     .GetApplianceSpaceStateByNumber(spaceNumber)

--- a/backend/app/Savor22b/Action/BuyShopItemAction.cs
+++ b/backend/app/Savor22b/Action/BuyShopItemAction.cs
@@ -65,9 +65,10 @@ public class BuyShopItemAction : SVRAction
         IAccountStateDelta states = ctx.PreviousStates;
         Address Recipient = Addresses.ShopVaultAddress;
 
-        InventoryState inventoryState = states.GetState(ctx.Signer) is Dictionary stateEncoded
-            ? new InventoryState(stateEncoded)
-            : new InventoryState();
+        RootState rootState = states.GetState(ctx.Signer) is Dictionary rootStateEncoded
+            ? new RootState(rootStateEncoded)
+            : new RootState();
+        var inventoryState = rootState.InventoryState;
 
         var desiredEquipment = FindRandomSeedItem();
         var itemState = new ItemState(ItemStateID, desiredEquipment.ID);
@@ -79,7 +80,8 @@ public class BuyShopItemAction : SVRAction
             allowNegativeBalance: false
         );
         inventoryState = inventoryState.AddItem(itemState);
+        rootState.SetInventoryState(inventoryState);
 
-        return states.SetState(ctx.Signer, inventoryState.Serialize());
+        return states.SetState(ctx.Signer, rootState.Serialize());
     }
 }

--- a/backend/app/Savor22b/Action/CancelFoodAction.cs
+++ b/backend/app/Savor22b/Action/CancelFoodAction.cs
@@ -1,0 +1,116 @@
+namespace Savor22b.Action;
+
+using System;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Headless.Extensions;
+using Libplanet.State;
+using Savor22b.Action.Exceptions;
+using Savor22b.Action.Util;
+using Savor22b.States;
+
+[ActionType(nameof(CancelFoodAction))]
+public class CancelFoodAction : SVRAction
+{
+    public Guid FoodStateID;
+
+    public CancelFoodAction() { }
+
+    public CancelFoodAction(Guid foodStateID)
+    {
+        FoodStateID = foodStateID;
+    }
+
+    protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+        new Dictionary<string, IValue>()
+        {
+            [nameof(FoodStateID)] = FoodStateID.Serialize(),
+        }.ToImmutableDictionary();
+
+    protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+    {
+        FoodStateID = plainValue[nameof(FoodStateID)].ToGuid();
+    }
+
+    public override IAccountStateDelta Execute(IActionContext ctx)
+    {
+        if (ctx.Rehearsal)
+        {
+            return ctx.PreviousStates;
+        }
+
+        IAccountStateDelta states = ctx.PreviousStates;
+
+        RootState rootState = states.GetState(ctx.Signer) is Dictionary rootStateEncoded
+            ? new RootState(rootStateEncoded)
+            : new RootState();
+
+        Validation.EnsureVillageStateExists(rootState);
+
+        InventoryState inventoryState = rootState.InventoryState;
+        KitchenState kitchenState = rootState.VillageState!.HouseState.KitchenState;
+
+        var food = inventoryState.GetRefrigeratorItem(FoodStateID);
+
+        if (food is null)
+        {
+            throw new NotFoundDataException($"NotFound `{FoodStateID}` food state id");
+        }
+
+        if (food!.AvailableBlockIndex < ctx.BlockIndex)
+        {
+            throw new NotCookingException("This food is available");
+        }
+
+        foreach (var kitchenEquipmentStateId in food!.UsedKitchenEquipmentStateIds)
+        {
+            var kitchenEquipmentState = inventoryState.GetKitchenEquipmentState(
+                kitchenEquipmentStateId
+            );
+
+            if (kitchenEquipmentState is null)
+            {
+                throw new NotFoundDataException(
+                    $"NotFound `{kitchenEquipmentStateId}` kitchen equipment state id"
+                );
+            }
+
+            var kitchenEquipmentCategory = CsvDataHelper.GetKitchenEquipmentCategoryByID(
+                kitchenEquipmentState.KitchenEquipmentCategoryID
+            );
+
+            if (kitchenEquipmentCategory is null)
+            {
+                throw new NotFoundTableDataException("Not found category table");
+            }
+
+            if (kitchenEquipmentCategory!.Category == "main")
+            {
+                for (var i = 1; i < 4; i++)
+                {
+                    if (
+                        kitchenState
+                            .GetApplianceSpaceStateByNumber(i)
+                            .InstalledKitchenEquipmentStateId == kitchenEquipmentStateId
+                    )
+                    {
+                        kitchenState.GetApplianceSpaceStateByNumber(i).StopCooking();
+                    }
+                }
+            }
+            else
+            {
+                kitchenEquipmentState = kitchenEquipmentState.StopCooking();
+                inventoryState = inventoryState.RemoveKitchenEquipmentItem(
+                    kitchenEquipmentState.StateID
+                );
+                inventoryState = inventoryState.AddKitchenEquipmentItem(kitchenEquipmentState);
+            }
+        }
+        inventoryState = inventoryState.RemoveRefrigeratorItem(food.StateID);
+        rootState.SetInventoryState(inventoryState);
+
+        return states.SetState(ctx.Signer, rootState.Serialize());
+    }
+}

--- a/backend/app/Savor22b/Action/CreateFoodAction.cs
+++ b/backend/app/Savor22b/Action/CreateFoodAction.cs
@@ -166,6 +166,7 @@ public class CreateFoodAction : SVRAction
             }
 
             var statusChangedEquipment = kitchenEquipment.StartCooking(
+                recipe.ResultFoodID,
                 currentBlockIndex,
                 durationBlock
             );
@@ -231,7 +232,7 @@ public class CreateFoodAction : SVRAction
                 );
             }
 
-            space.StartCooking(currentBlockIndex, durationBlock);
+            space.StartCooking(recipe.ResultFoodID, currentBlockIndex, durationBlock);
 
             requiredKitchenCategoryIds = requiredKitchenCategoryIds.Remove(
                 kitchenEquipment.KitchenEquipmentCategoryID

--- a/backend/app/Savor22b/Action/CreateFoodAction.cs
+++ b/backend/app/Savor22b/Action/CreateFoodAction.cs
@@ -377,7 +377,8 @@ public class CreateFoodAction : SVRAction
         Recipe recipe,
         IRandom random,
         long currentBlockIndex,
-        long durationBlock
+        long durationBlock,
+        ImmutableList<Guid> usedKitchenEquipmentStateIds
     )
     {
         var gradeExtractor = new GradeExtractor(random, 0.1);
@@ -400,7 +401,8 @@ public class CreateFoodAction : SVRAction
             generatedStat.ATK,
             generatedStat.DEF,
             generatedStat.SPD,
-            currentBlockIndex + durationBlock
+            currentBlockIndex + durationBlock,
+            usedKitchenEquipmentStateIds
         );
 
         return food;
@@ -450,7 +452,24 @@ public class CreateFoodAction : SVRAction
         );
         inventoryState = CheckAndRemoveEdibles(recipe, inventoryState, RefrigeratorStateIdsToUse);
 
-        RefrigeratorState food = GenerateFood(recipe, ctx.Random, ctx.BlockIndex, durationBlock);
+        var usedKitchenEquipmentStateIds = KitchenEquipmentStateIdsToUse.ToImmutableList();
+
+        foreach (var spaceNumber in ApplianceSpaceNumbersToUse)
+        {
+            var space = houseState.KitchenState.GetApplianceSpaceStateByNumber(spaceNumber);
+
+            usedKitchenEquipmentStateIds = usedKitchenEquipmentStateIds.Add(
+                space.InstalledKitchenEquipmentStateId!.Value
+            );
+        }
+
+        RefrigeratorState food = GenerateFood(
+            recipe,
+            ctx.Random,
+            ctx.BlockIndex,
+            durationBlock,
+            usedKitchenEquipmentStateIds
+        );
         inventoryState = inventoryState.AddRefrigeratorItem(food);
 
         rootState.SetInventoryState(inventoryState);

--- a/backend/app/Savor22b/Action/CreateFoodAction.cs
+++ b/backend/app/Savor22b/Action/CreateFoodAction.cs
@@ -166,7 +166,6 @@ public class CreateFoodAction : SVRAction
             }
 
             var statusChangedEquipment = kitchenEquipment.StartCooking(
-                recipe.ResultFoodID,
                 currentBlockIndex,
                 durationBlock
             );
@@ -232,7 +231,7 @@ public class CreateFoodAction : SVRAction
                 );
             }
 
-            space.StartCooking(recipe.ResultFoodID, currentBlockIndex, durationBlock);
+            space.StartCooking(currentBlockIndex, durationBlock);
 
             requiredKitchenCategoryIds = requiredKitchenCategoryIds.Remove(
                 kitchenEquipment.KitchenEquipmentCategoryID

--- a/backend/app/Savor22b/Action/CreateFoodAction.cs
+++ b/backend/app/Savor22b/Action/CreateFoodAction.cs
@@ -373,7 +373,7 @@ public class CreateFoodAction : SVRAction
         }
     }
 
-    private RefrigeratorState GenerateFood(
+    private RefrigeratorState CreateFood(
         Recipe recipe,
         IRandom random,
         long currentBlockIndex,
@@ -463,7 +463,7 @@ public class CreateFoodAction : SVRAction
             );
         }
 
-        RefrigeratorState food = GenerateFood(
+        RefrigeratorState food = CreateFood(
             recipe,
             ctx.Random,
             ctx.BlockIndex,

--- a/backend/app/Savor22b/Action/Exceptions/NotCookingException.cs
+++ b/backend/app/Savor22b/Action/Exceptions/NotCookingException.cs
@@ -1,8 +1,0 @@
-namespace Savor22b.Action.Exceptions;
-
-[Serializable]
-public class NotCookingException : ActionException
-{
-    public NotCookingException(string message, int? errorCode = null)
-        : base(message, "NotCooking", errorCode) { }
-}

--- a/backend/app/Savor22b/Action/Exceptions/NotCookingException.cs
+++ b/backend/app/Savor22b/Action/Exceptions/NotCookingException.cs
@@ -1,0 +1,8 @@
+namespace Savor22b.Action.Exceptions;
+
+[Serializable]
+public class NotCookingException : ActionException
+{
+    public NotCookingException(string message, int? errorCode = null)
+        : base(message, "NotCooking", errorCode) { }
+}

--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -118,7 +118,7 @@ public class Query : ObjectGraphType
         );
 
         Field<NonNullGraphType<StringGraphType>>(
-            "createAction_GenerateFood",
+            "createAction_CreateFood",
             description: "Generate Food",
             arguments: new QueryArguments(
                 new QueryArgument<NonNullGraphType<StringGraphType>>
@@ -156,7 +156,7 @@ public class Query : ObjectGraphType
                 var action = new CreateFoodAction(
                     context.GetArgument<int>("recipeID"),
                     Guid.NewGuid(),
-                    context.GetArgument<List<Guid>>("refrigeratorStateIDs"),
+                    context.GetArgument<List<Guid>>("refrigeratorStateIdsToUse"),
                     context.GetArgument<List<Guid>>("kitchenEquipmentStateIdsToUse"),
                     context.GetArgument<List<int>>("applianceSpaceNumbersToUse")
                 );
@@ -380,54 +380,6 @@ public class Query : ObjectGraphType
         );
 
         Field<NonNullGraphType<StringGraphType>>(
-            "createAction_CreateFood",
-            description: "Create Food",
-            arguments: new QueryArguments(
-                new QueryArgument<NonNullGraphType<StringGraphType>>
-                {
-                    Name = "publicKey",
-                    Description = "The base64-encoded public key for Transaction.",
-                },
-                new QueryArgument<NonNullGraphType<ListGraphType<GuidGraphType>>>
-                {
-                    Name = "refrigeratorStateIdsToUse",
-                    Description = "refrigerator state ID list for use",
-                },
-                new QueryArgument<NonNullGraphType<ListGraphType<GuidGraphType>>>
-                {
-                    Name = "kitchenEquipmentStateIdsToUse",
-                    Description = "kitchen equipment state ID list for use",
-                },
-                new QueryArgument<NonNullGraphType<ListGraphType<IntGraphType>>>
-                {
-                    Name = "applianceSpaceNumbersToUse",
-                    Description = "appliance space number list for use",
-                }
-            ),
-            resolve: context =>
-            {
-                var publicKey = new PublicKey(
-                    ByteUtil.ParseHex(context.GetArgument<string>("publicKey"))
-                );
-
-                var action = new CreateFoodAction(
-                    context.GetArgument<int>("recipeID"),
-                    Guid.NewGuid(),
-                    context.GetArgument<List<Guid>>("refrigeratorStateIdsToUse"),
-                    context.GetArgument<List<Guid>>("kitchenEquipmentStateIdsToUse"),
-                    context.GetArgument<List<int>>("applianceSpaceNumbersToUse")
-                );
-
-                return new GetUnsignedTransactionHex(
-                    action,
-                    publicKey,
-                    _blockChain,
-                    _swarm
-                ).UnsignedTransactionHex;
-            }
-        );
-
-        Field<NonNullGraphType<StringGraphType>>(
             "createAction_BuyShopItem",
             description: "Buy Shop Item",
             arguments: new QueryArguments(
@@ -471,6 +423,11 @@ public class Query : ObjectGraphType
                     Name = "publicKey",
                     Description = "The base64-encoded public key for Transaction.",
                 },
+                new QueryArgument<GuidGraphType>
+                {
+                    Name = "kitchenEquipmentStateID",
+                    Description = "Kitchen Equipment State Id for install",
+                },
                 new QueryArgument<IntGraphType>
                 {
                     Name = "spaceNumber",
@@ -484,7 +441,7 @@ public class Query : ObjectGraphType
                 );
 
                 var action = new InstallKitchenEquipmentAction(
-                    Guid.NewGuid(),
+                    context.GetArgument<Guid>("kitchenEquipmentStateID"),
                     context.GetArgument<int>("spaceNumber")
                 );
 

--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -497,6 +497,38 @@ public class Query : ObjectGraphType
             }
         );
 
+        Field<NonNullGraphType<StringGraphType>>(
+            "createAction_CancelFoodAction",
+            description: "Cancel Food",
+            arguments: new QueryArguments(
+                new QueryArgument<NonNullGraphType<StringGraphType>>
+                {
+                    Name = "publicKey",
+                    Description = "The base64-encoded public key for Transaction.",
+                },
+                new QueryArgument<NonNullGraphType<GuidGraphType>>
+                {
+                    Name = "foodStateId",
+                    Description = "Food state Id (Guid)",
+                }
+            ),
+            resolve: context =>
+            {
+                var publicKey = new PublicKey(
+                    ByteUtil.ParseHex(context.GetArgument<string>("publicKey"))
+                );
+
+                var action = new CancelFoodAction(context.GetArgument<Guid>("foodStateId"));
+
+                return new GetUnsignedTransactionHex(
+                    action,
+                    publicKey,
+                    _blockChain,
+                    _swarm
+                ).UnsignedTransactionHex;
+            }
+        );
+
         AddField(new CalculateRelocationCostQuery());
         AddField(new VillagesQuery(blockChain));
         AddField(new ShopQuery());

--- a/backend/app/Savor22b/States/ApplianceSpaceState.cs
+++ b/backend/app/Savor22b/States/ApplianceSpaceState.cs
@@ -17,11 +17,14 @@ public class ApplianceSpaceState : State
     public ApplianceSpaceState(
         int spaceNumber,
         Guid? installedKitchenEquipmentStateId,
+        int? cookingFoodId,
         long? cookingDurationBlock,
-        long? cookingStartedBlockIndex)
+        long? cookingStartedBlockIndex
+    )
     {
         SpaceNumber = spaceNumber;
         InstalledKitchenEquipmentStateId = installedKitchenEquipmentStateId;
+        CookingFoodId = cookingFoodId;
         CookingDurationBlock = cookingDurationBlock;
         CookingStartedBlockIndex = cookingStartedBlockIndex;
     }
@@ -29,7 +32,10 @@ public class ApplianceSpaceState : State
     public ApplianceSpaceState(Dictionary encoded)
     {
         SpaceNumber = encoded[nameof(SpaceNumber)].ToInteger();
-        InstalledKitchenEquipmentStateId = encoded[nameof(InstalledKitchenEquipmentStateId)].ToNullableGuid();
+        InstalledKitchenEquipmentStateId = encoded[
+            nameof(InstalledKitchenEquipmentStateId)
+        ].ToNullableGuid();
+        CookingFoodId = encoded[nameof(CookingFoodId)].ToNullableInteger();
         CookingDurationBlock = encoded[nameof(CookingDurationBlock)].ToNullableLong();
         CookingStartedBlockIndex = encoded[nameof(CookingStartedBlockIndex)].ToNullableLong();
     }
@@ -37,6 +43,8 @@ public class ApplianceSpaceState : State
     public int SpaceNumber { get; private set; }
 
     public Guid? InstalledKitchenEquipmentStateId { get; private set; }
+
+    public int? CookingFoodId { get; private set; }
 
     public long? CookingDurationBlock { get; private set; }
 
@@ -47,28 +55,49 @@ public class ApplianceSpaceState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(SpaceNumber), SpaceNumber.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(InstalledKitchenEquipmentStateId), InstalledKitchenEquipmentStateId.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(InstalledKitchenEquipmentStateId),
+                InstalledKitchenEquipmentStateId.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingFoodId), CookingFoodId.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingDurationBlock),
+                CookingDurationBlock.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingStartedBlockIndex),
+                CookingStartedBlockIndex.Serialize()
+            ),
         };
         return new Dictionary(pairs);
     }
 
     public ApplianceSpaceState InstallKitchenEquipment(Guid installedKitchenEquipmentStateId)
     {
-        return new ApplianceSpaceState(SpaceNumber, installedKitchenEquipmentStateId, null, null);
+        return new ApplianceSpaceState(
+            SpaceNumber,
+            installedKitchenEquipmentStateId,
+            null,
+            null,
+            null
+        );
     }
 
     public void UnInstallKitchenEquipment()
     {
         InstalledKitchenEquipmentStateId = null;
+        CookingFoodId = null;
         CookingStartedBlockIndex = null;
         CookingDurationBlock = null;
     }
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
+        return BlockUtil.CalculateIsInProgress(
+            currentBlockIndex,
+            CookingStartedBlockIndex ?? 0,
+            CookingDurationBlock ?? 0
+        );
     }
 
     public bool EquipmentIsPresent()
@@ -76,8 +105,9 @@ public class ApplianceSpaceState : State
         return InstalledKitchenEquipmentStateId is not null;
     }
 
-    public void StartCooking(long currentBlockIndex, long cookingDurationBlock)
+    public void StartCooking(int foodId, long currentBlockIndex, long cookingDurationBlock)
     {
+        CookingFoodId = foodId;
         CookingStartedBlockIndex = currentBlockIndex;
         CookingDurationBlock = cookingDurationBlock;
     }
@@ -95,7 +125,8 @@ public class ApplianceSpaceState : State
         }
 
         ApplianceSpaceState other = (ApplianceSpaceState)obj;
-        return SpaceNumber == other.SpaceNumber && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
+        return SpaceNumber == other.SpaceNumber
+            && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
     }
 
     public override int GetHashCode()

--- a/backend/app/Savor22b/States/ApplianceSpaceState.cs
+++ b/backend/app/Savor22b/States/ApplianceSpaceState.cs
@@ -18,7 +18,8 @@ public class ApplianceSpaceState : State
         int spaceNumber,
         Guid? installedKitchenEquipmentStateId,
         long? cookingDurationBlock,
-        long? cookingStartedBlockIndex)
+        long? cookingStartedBlockIndex
+    )
     {
         SpaceNumber = spaceNumber;
         InstalledKitchenEquipmentStateId = installedKitchenEquipmentStateId;
@@ -29,7 +30,9 @@ public class ApplianceSpaceState : State
     public ApplianceSpaceState(Dictionary encoded)
     {
         SpaceNumber = encoded[nameof(SpaceNumber)].ToInteger();
-        InstalledKitchenEquipmentStateId = encoded[nameof(InstalledKitchenEquipmentStateId)].ToNullableGuid();
+        InstalledKitchenEquipmentStateId = encoded[
+            nameof(InstalledKitchenEquipmentStateId)
+        ].ToNullableGuid();
         CookingDurationBlock = encoded[nameof(CookingDurationBlock)].ToNullableLong();
         CookingStartedBlockIndex = encoded[nameof(CookingStartedBlockIndex)].ToNullableLong();
     }
@@ -47,9 +50,18 @@ public class ApplianceSpaceState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(SpaceNumber), SpaceNumber.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(InstalledKitchenEquipmentStateId), InstalledKitchenEquipmentStateId.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(InstalledKitchenEquipmentStateId),
+                InstalledKitchenEquipmentStateId.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingDurationBlock),
+                CookingDurationBlock.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingStartedBlockIndex),
+                CookingStartedBlockIndex.Serialize()
+            ),
         };
         return new Dictionary(pairs);
     }
@@ -68,7 +80,11 @@ public class ApplianceSpaceState : State
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
+        return BlockUtil.CalculateIsInProgress(
+            currentBlockIndex,
+            CookingStartedBlockIndex ?? 0,
+            CookingDurationBlock ?? 0
+        );
     }
 
     public bool EquipmentIsPresent()
@@ -80,6 +96,12 @@ public class ApplianceSpaceState : State
     {
         CookingStartedBlockIndex = currentBlockIndex;
         CookingDurationBlock = cookingDurationBlock;
+    }
+
+    public void StopCooking()
+    {
+        CookingStartedBlockIndex = null;
+        CookingDurationBlock = null;
     }
 
     public override bool Equals(object obj)
@@ -95,7 +117,8 @@ public class ApplianceSpaceState : State
         }
 
         ApplianceSpaceState other = (ApplianceSpaceState)obj;
-        return SpaceNumber == other.SpaceNumber && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
+        return SpaceNumber == other.SpaceNumber
+            && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
     }
 
     public override int GetHashCode()

--- a/backend/app/Savor22b/States/ApplianceSpaceState.cs
+++ b/backend/app/Savor22b/States/ApplianceSpaceState.cs
@@ -17,14 +17,11 @@ public class ApplianceSpaceState : State
     public ApplianceSpaceState(
         int spaceNumber,
         Guid? installedKitchenEquipmentStateId,
-        int? cookingFoodId,
         long? cookingDurationBlock,
-        long? cookingStartedBlockIndex
-    )
+        long? cookingStartedBlockIndex)
     {
         SpaceNumber = spaceNumber;
         InstalledKitchenEquipmentStateId = installedKitchenEquipmentStateId;
-        CookingFoodId = cookingFoodId;
         CookingDurationBlock = cookingDurationBlock;
         CookingStartedBlockIndex = cookingStartedBlockIndex;
     }
@@ -32,10 +29,7 @@ public class ApplianceSpaceState : State
     public ApplianceSpaceState(Dictionary encoded)
     {
         SpaceNumber = encoded[nameof(SpaceNumber)].ToInteger();
-        InstalledKitchenEquipmentStateId = encoded[
-            nameof(InstalledKitchenEquipmentStateId)
-        ].ToNullableGuid();
-        CookingFoodId = encoded[nameof(CookingFoodId)].ToNullableInteger();
+        InstalledKitchenEquipmentStateId = encoded[nameof(InstalledKitchenEquipmentStateId)].ToNullableGuid();
         CookingDurationBlock = encoded[nameof(CookingDurationBlock)].ToNullableLong();
         CookingStartedBlockIndex = encoded[nameof(CookingStartedBlockIndex)].ToNullableLong();
     }
@@ -43,8 +37,6 @@ public class ApplianceSpaceState : State
     public int SpaceNumber { get; private set; }
 
     public Guid? InstalledKitchenEquipmentStateId { get; private set; }
-
-    public int? CookingFoodId { get; private set; }
 
     public long? CookingDurationBlock { get; private set; }
 
@@ -55,49 +47,28 @@ public class ApplianceSpaceState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(SpaceNumber), SpaceNumber.Serialize()),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(InstalledKitchenEquipmentStateId),
-                InstalledKitchenEquipmentStateId.Serialize()
-            ),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingFoodId), CookingFoodId.Serialize()),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(CookingDurationBlock),
-                CookingDurationBlock.Serialize()
-            ),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(CookingStartedBlockIndex),
-                CookingStartedBlockIndex.Serialize()
-            ),
+            new KeyValuePair<IKey, IValue>((Text)nameof(InstalledKitchenEquipmentStateId), InstalledKitchenEquipmentStateId.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
         };
         return new Dictionary(pairs);
     }
 
     public ApplianceSpaceState InstallKitchenEquipment(Guid installedKitchenEquipmentStateId)
     {
-        return new ApplianceSpaceState(
-            SpaceNumber,
-            installedKitchenEquipmentStateId,
-            null,
-            null,
-            null
-        );
+        return new ApplianceSpaceState(SpaceNumber, installedKitchenEquipmentStateId, null, null);
     }
 
     public void UnInstallKitchenEquipment()
     {
         InstalledKitchenEquipmentStateId = null;
-        CookingFoodId = null;
         CookingStartedBlockIndex = null;
         CookingDurationBlock = null;
     }
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(
-            currentBlockIndex,
-            CookingStartedBlockIndex ?? 0,
-            CookingDurationBlock ?? 0
-        );
+        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
     }
 
     public bool EquipmentIsPresent()
@@ -105,9 +76,8 @@ public class ApplianceSpaceState : State
         return InstalledKitchenEquipmentStateId is not null;
     }
 
-    public void StartCooking(int foodId, long currentBlockIndex, long cookingDurationBlock)
+    public void StartCooking(long currentBlockIndex, long cookingDurationBlock)
     {
-        CookingFoodId = foodId;
         CookingStartedBlockIndex = currentBlockIndex;
         CookingDurationBlock = cookingDurationBlock;
     }
@@ -125,8 +95,7 @@ public class ApplianceSpaceState : State
         }
 
         ApplianceSpaceState other = (ApplianceSpaceState)obj;
-        return SpaceNumber == other.SpaceNumber
-            && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
+        return SpaceNumber == other.SpaceNumber && InstalledKitchenEquipmentStateId == other.InstalledKitchenEquipmentStateId;
     }
 
     public override int GetHashCode()

--- a/backend/app/Savor22b/States/KitchenEquipmentState.cs
+++ b/backend/app/Savor22b/States/KitchenEquipmentState.cs
@@ -6,7 +6,13 @@ using Libplanet.Headless.Extensions;
 
 public class KitchenEquipmentState : State
 {
-    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID, long cookingStartedBlockIndex, long cookingDurationBlock)
+    public KitchenEquipmentState(
+        Guid stateID,
+        int kitchenEquipmentID,
+        int kitchenEquipmentCategoryID,
+        long cookingStartedBlockIndex,
+        long cookingDurationBlock
+    )
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
@@ -15,7 +21,11 @@ public class KitchenEquipmentState : State
         CookingDurationBlock = cookingDurationBlock;
     }
 
-    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID)
+    public KitchenEquipmentState(
+        Guid stateID,
+        int kitchenEquipmentID,
+        int kitchenEquipmentCategoryID
+    )
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
@@ -48,23 +58,49 @@ public class KitchenEquipmentState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(StateID), StateID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentID), KitchenEquipmentID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentCategoryID), KitchenEquipmentCategoryID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(KitchenEquipmentID),
+                KitchenEquipmentID.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(KitchenEquipmentCategoryID),
+                KitchenEquipmentCategoryID.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingStartedBlockIndex),
+                CookingStartedBlockIndex.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingDurationBlock),
+                CookingDurationBlock.Serialize()
+            ),
         };
         return new Dictionary(pairs);
     }
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
+        return BlockUtil.CalculateIsInProgress(
+            currentBlockIndex,
+            CookingStartedBlockIndex ?? 0,
+            CookingDurationBlock ?? 0
+        );
     }
 
     public KitchenEquipmentState StartCooking(long currentBlockIndex, long cookingDurationBlock)
     {
         return new KitchenEquipmentState(
-            StateID, KitchenEquipmentID, KitchenEquipmentCategoryID, currentBlockIndex, cookingDurationBlock);
+            StateID,
+            KitchenEquipmentID,
+            KitchenEquipmentCategoryID,
+            currentBlockIndex,
+            cookingDurationBlock
+        );
+    }
+
+    public KitchenEquipmentState StopCooking()
+    {
+        return new KitchenEquipmentState(StateID, KitchenEquipmentID, KitchenEquipmentCategoryID);
     }
 
     public override bool Equals(object obj)
@@ -93,5 +129,4 @@ public class KitchenEquipmentState : State
             return hash;
         }
     }
-
 }

--- a/backend/app/Savor22b/States/KitchenEquipmentState.cs
+++ b/backend/app/Savor22b/States/KitchenEquipmentState.cs
@@ -6,20 +6,33 @@ using Libplanet.Headless.Extensions;
 
 public class KitchenEquipmentState : State
 {
-    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID, long cookingStartedBlockIndex, long cookingDurationBlock)
+    public KitchenEquipmentState(
+        Guid stateID,
+        int kitchenEquipmentID,
+        int kitchenEquipmentCategoryID,
+        int cookingFoodId,
+        long cookingStartedBlockIndex,
+        long cookingDurationBlock
+    )
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
         KitchenEquipmentCategoryID = kitchenEquipmentCategoryID;
+        CookingFoodId = cookingFoodId;
         CookingStartedBlockIndex = cookingStartedBlockIndex;
         CookingDurationBlock = cookingDurationBlock;
     }
 
-    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID)
+    public KitchenEquipmentState(
+        Guid stateID,
+        int kitchenEquipmentID,
+        int kitchenEquipmentCategoryID
+    )
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
         KitchenEquipmentCategoryID = kitchenEquipmentCategoryID;
+        CookingFoodId = null;
         CookingStartedBlockIndex = null;
         CookingDurationBlock = null;
     }
@@ -29,6 +42,7 @@ public class KitchenEquipmentState : State
         StateID = encoded[nameof(StateID)].ToGuid();
         KitchenEquipmentID = encoded[nameof(KitchenEquipmentID)].ToInteger();
         KitchenEquipmentCategoryID = encoded[nameof(KitchenEquipmentCategoryID)].ToInteger();
+        CookingFoodId = encoded[nameof(CookingFoodId)].ToNullableInteger();
         CookingStartedBlockIndex = encoded[nameof(CookingStartedBlockIndex)].ToNullableLong();
         CookingDurationBlock = encoded[nameof(CookingDurationBlock)].ToNullableLong();
     }
@@ -39,6 +53,8 @@ public class KitchenEquipmentState : State
 
     public int KitchenEquipmentCategoryID { get; private set; }
 
+    public int? CookingFoodId { get; private set; }
+
     public long? CookingStartedBlockIndex { get; private set; }
 
     public long? CookingDurationBlock { get; private set; }
@@ -48,23 +64,50 @@ public class KitchenEquipmentState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(StateID), StateID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentID), KitchenEquipmentID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentCategoryID), KitchenEquipmentCategoryID.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(KitchenEquipmentID),
+                KitchenEquipmentID.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(KitchenEquipmentCategoryID),
+                KitchenEquipmentCategoryID.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingFoodId), CookingFoodId.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingStartedBlockIndex),
+                CookingStartedBlockIndex.Serialize()
+            ),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(CookingDurationBlock),
+                CookingDurationBlock.Serialize()
+            ),
         };
         return new Dictionary(pairs);
     }
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
+        return BlockUtil.CalculateIsInProgress(
+            currentBlockIndex,
+            CookingStartedBlockIndex ?? 0,
+            CookingDurationBlock ?? 0
+        );
     }
 
-    public KitchenEquipmentState StartCooking(long currentBlockIndex, long cookingDurationBlock)
+    public KitchenEquipmentState StartCooking(
+        int cookingFoodId,
+        long currentBlockIndex,
+        long cookingDurationBlock
+    )
     {
         return new KitchenEquipmentState(
-            StateID, KitchenEquipmentID, KitchenEquipmentCategoryID, currentBlockIndex, cookingDurationBlock);
+            StateID,
+            KitchenEquipmentID,
+            KitchenEquipmentCategoryID,
+            cookingFoodId,
+            currentBlockIndex,
+            cookingDurationBlock
+        );
     }
 
     public override bool Equals(object obj)
@@ -93,5 +136,4 @@ public class KitchenEquipmentState : State
             return hash;
         }
     }
-
 }

--- a/backend/app/Savor22b/States/KitchenEquipmentState.cs
+++ b/backend/app/Savor22b/States/KitchenEquipmentState.cs
@@ -6,33 +6,20 @@ using Libplanet.Headless.Extensions;
 
 public class KitchenEquipmentState : State
 {
-    public KitchenEquipmentState(
-        Guid stateID,
-        int kitchenEquipmentID,
-        int kitchenEquipmentCategoryID,
-        int cookingFoodId,
-        long cookingStartedBlockIndex,
-        long cookingDurationBlock
-    )
+    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID, long cookingStartedBlockIndex, long cookingDurationBlock)
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
         KitchenEquipmentCategoryID = kitchenEquipmentCategoryID;
-        CookingFoodId = cookingFoodId;
         CookingStartedBlockIndex = cookingStartedBlockIndex;
         CookingDurationBlock = cookingDurationBlock;
     }
 
-    public KitchenEquipmentState(
-        Guid stateID,
-        int kitchenEquipmentID,
-        int kitchenEquipmentCategoryID
-    )
+    public KitchenEquipmentState(Guid stateID, int kitchenEquipmentID, int kitchenEquipmentCategoryID)
     {
         StateID = stateID;
         KitchenEquipmentID = kitchenEquipmentID;
         KitchenEquipmentCategoryID = kitchenEquipmentCategoryID;
-        CookingFoodId = null;
         CookingStartedBlockIndex = null;
         CookingDurationBlock = null;
     }
@@ -42,7 +29,6 @@ public class KitchenEquipmentState : State
         StateID = encoded[nameof(StateID)].ToGuid();
         KitchenEquipmentID = encoded[nameof(KitchenEquipmentID)].ToInteger();
         KitchenEquipmentCategoryID = encoded[nameof(KitchenEquipmentCategoryID)].ToInteger();
-        CookingFoodId = encoded[nameof(CookingFoodId)].ToNullableInteger();
         CookingStartedBlockIndex = encoded[nameof(CookingStartedBlockIndex)].ToNullableLong();
         CookingDurationBlock = encoded[nameof(CookingDurationBlock)].ToNullableLong();
     }
@@ -53,8 +39,6 @@ public class KitchenEquipmentState : State
 
     public int KitchenEquipmentCategoryID { get; private set; }
 
-    public int? CookingFoodId { get; private set; }
-
     public long? CookingStartedBlockIndex { get; private set; }
 
     public long? CookingDurationBlock { get; private set; }
@@ -64,50 +48,23 @@ public class KitchenEquipmentState : State
         var pairs = new[]
         {
             new KeyValuePair<IKey, IValue>((Text)nameof(StateID), StateID.Serialize()),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(KitchenEquipmentID),
-                KitchenEquipmentID.Serialize()
-            ),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(KitchenEquipmentCategoryID),
-                KitchenEquipmentCategoryID.Serialize()
-            ),
-            new KeyValuePair<IKey, IValue>((Text)nameof(CookingFoodId), CookingFoodId.Serialize()),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(CookingStartedBlockIndex),
-                CookingStartedBlockIndex.Serialize()
-            ),
-            new KeyValuePair<IKey, IValue>(
-                (Text)nameof(CookingDurationBlock),
-                CookingDurationBlock.Serialize()
-            ),
+            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentID), KitchenEquipmentID.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(KitchenEquipmentCategoryID), KitchenEquipmentCategoryID.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingStartedBlockIndex), CookingStartedBlockIndex.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(CookingDurationBlock), CookingDurationBlock.Serialize()),
         };
         return new Dictionary(pairs);
     }
 
     public bool IsInUse(long currentBlockIndex)
     {
-        return BlockUtil.CalculateIsInProgress(
-            currentBlockIndex,
-            CookingStartedBlockIndex ?? 0,
-            CookingDurationBlock ?? 0
-        );
+        return BlockUtil.CalculateIsInProgress(currentBlockIndex, CookingStartedBlockIndex ?? 0, CookingDurationBlock ?? 0);
     }
 
-    public KitchenEquipmentState StartCooking(
-        int cookingFoodId,
-        long currentBlockIndex,
-        long cookingDurationBlock
-    )
+    public KitchenEquipmentState StartCooking(long currentBlockIndex, long cookingDurationBlock)
     {
         return new KitchenEquipmentState(
-            StateID,
-            KitchenEquipmentID,
-            KitchenEquipmentCategoryID,
-            cookingFoodId,
-            currentBlockIndex,
-            cookingDurationBlock
-        );
+            StateID, KitchenEquipmentID, KitchenEquipmentCategoryID, currentBlockIndex, cookingDurationBlock);
     }
 
     public override bool Equals(object obj)
@@ -136,4 +93,5 @@ public class KitchenEquipmentState : State
             return hash;
         }
     }
+
 }

--- a/backend/app/Savor22b/States/RefrigeratorState.cs
+++ b/backend/app/Savor22b/States/RefrigeratorState.cs
@@ -3,6 +3,7 @@ namespace Savor22b.States;
 using Bencodex.Types;
 using Savor22b.Constants;
 using Libplanet.Headless.Extensions;
+using System.Collections.Immutable;
 
 public class RefrigeratorState : State
 {
@@ -15,7 +16,8 @@ public class RefrigeratorState : State
         int def,
         int atk,
         int spd,
-        long? availableBlockIndex
+        long? availableBlockIndex,
+        ImmutableList<Guid> usedKitchenEquipmentStateIds
     )
     {
         StateID = stateID;
@@ -27,6 +29,7 @@ public class RefrigeratorState : State
         ATK = atk;
         SPD = spd;
         AvailableBlockIndex = availableBlockIndex;
+        UsedKitchenEquipmentStateIds = usedKitchenEquipmentStateIds;
     }
 
     public static RefrigeratorState CreateIngredient(
@@ -39,7 +42,18 @@ public class RefrigeratorState : State
         int spd
     )
     {
-        return new RefrigeratorState(stateID, ingredientID, null, grade, hp, def, atk, spd, null);
+        return new RefrigeratorState(
+            stateID,
+            ingredientID,
+            null,
+            grade,
+            hp,
+            def,
+            atk,
+            spd,
+            null,
+            ImmutableList<Guid>.Empty
+        );
     }
 
     public static RefrigeratorState CreateFood(
@@ -50,7 +64,8 @@ public class RefrigeratorState : State
         int def,
         int atk,
         int spd,
-        long? availableBlockIndex
+        long availableBlockIndex,
+        ImmutableList<Guid> usedKitchenEquipmentStateIds
     )
     {
         return new RefrigeratorState(
@@ -62,7 +77,8 @@ public class RefrigeratorState : State
             def,
             atk,
             spd,
-            availableBlockIndex
+            availableBlockIndex,
+            usedKitchenEquipmentStateIds
         );
     }
 
@@ -77,6 +93,9 @@ public class RefrigeratorState : State
         IngredientID = encoded[nameof(IngredientID)].ToNullableInteger();
         FoodID = encoded[nameof(FoodID)].ToNullableInteger();
         AvailableBlockIndex = encoded[nameof(AvailableBlockIndex)].ToNullableLong();
+        UsedKitchenEquipmentStateIds = ((List)encoded[nameof(UsedKitchenEquipmentStateIds)])
+            .Select(e => e.ToGuid())
+            .ToImmutableList();
     }
 
     public Guid StateID { get; set; }
@@ -97,6 +116,8 @@ public class RefrigeratorState : State
 
     public long? AvailableBlockIndex { get; set; }
 
+    public ImmutableList<Guid> UsedKitchenEquipmentStateIds { get; set; }
+
     public IValue Serialize()
     {
         var pairs = new List<KeyValuePair<IKey, IValue>>
@@ -109,6 +130,10 @@ public class RefrigeratorState : State
             new KeyValuePair<IKey, IValue>((Text)nameof(SPD), SPD.Serialize()),
             new KeyValuePair<IKey, IValue>((Text)nameof(IngredientID), IngredientID.Serialize()),
             new KeyValuePair<IKey, IValue>((Text)nameof(FoodID), FoodID.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(UsedKitchenEquipmentStateIds),
+                new List(UsedKitchenEquipmentStateIds.Select(element => element.Serialize()))
+            ),
             new KeyValuePair<IKey, IValue>(
                 (Text)nameof(AvailableBlockIndex),
                 AvailableBlockIndex.Serialize()


### PR DESCRIPTION
조리 취소 기능을 만들었습니다. 간단한데 아직 활성화되지 않은 음식에 취소 요청을 하면 사용했던 장비들의 음식 조리를 취소해주고 그 음식도 삭제합니다.
테스트하면서 발견한 mutation 관련 오류도 수정했습니다.