### PR TITLE
[SVR-121] 종자의 마을별 제한 기능 추가

### DIFF
--- a/backend/app/Savor22b.Tests/Action/UseRandomSeedItemActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/UseRandomSeedItemActionTests.cs
@@ -10,15 +10,14 @@ using Libplanet;
 
 public class UseRandomSeedItemActionTests : ActionTests
 {
-    public UseRandomSeedItemActionTests()
-    {
-    }
+    public UseRandomSeedItemActionTests() { }
 
     [Fact]
     public void UseRandomSeedItemActionExecute_AddsSeedToSeedStateList()
     {
         var seedStateID = Guid.NewGuid();
         var random = new DummyRandom(1);
+        var villageId = 1;
 
         IAccountStateDelta state = new DummyState();
         RootState beforeRootState = new RootState();
@@ -28,19 +27,24 @@ public class UseRandomSeedItemActionTests : ActionTests
         beforeInventoryState = beforeInventoryState.AddItem(itemState);
 
         beforeRootState.SetInventoryState(beforeInventoryState);
+        beforeRootState.SetVillageState(
+            new VillageState(new HouseState(villageId, 0, 0, new KitchenState()))
+        );
 
         state = state.SetState(SignerAddress(), beforeRootState.Serialize());
 
         var action = new UseRandomSeedItemAction(seedStateID, itemState.StateID);
 
-        state = action.Execute(new DummyActionContext
-        {
-            PreviousStates = state,
-            Signer = SignerAddress(),
-            Random = random,
-            Rehearsal = false,
-            BlockIndex = 1,
-        });
+        state = action.Execute(
+            new DummyActionContext
+            {
+                PreviousStates = state,
+                Signer = SignerAddress(),
+                Random = random,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }
+        );
 
         var rootStateEncoded = state.GetState(SignerAddress());
         RootState rootState = rootStateEncoded is Bencodex.Types.Dictionary bdict
@@ -59,8 +63,12 @@ public class UseRandomSeedItemActionTests : ActionTests
     [InlineData(100)]
     [InlineData(1000)]
     [InlineData(10000)]
-    public void UseRandomSeedItemActionExecute_AddsSeedStateToExistsSeedsList(int existsSeedsListLength)
+    public void UseRandomSeedItemActionExecute_AddsSeedStateToExistsSeedsList(
+        int existsSeedsListLength
+    )
     {
+        int villageId = 1;
+
         IAccountStateDelta state = new DummyState();
         var itemState = new ItemState(Guid.NewGuid(), 1);
         RootState rootState = new RootState();
@@ -74,6 +82,9 @@ public class UseRandomSeedItemActionTests : ActionTests
 
         beforeInventoryState = beforeInventoryState.AddItem(itemState);
         rootState.SetInventoryState(beforeInventoryState);
+        rootState.SetVillageState(
+            new VillageState(new HouseState(villageId, 0, 0, new KitchenState()))
+        );
 
         state = state.SetState(SignerAddress(), rootState.Serialize());
 
@@ -81,14 +92,16 @@ public class UseRandomSeedItemActionTests : ActionTests
 
         var action = new UseRandomSeedItemAction(Guid.NewGuid(), itemState.StateID);
 
-        state = action.Execute(new DummyActionContext
-        {
-            PreviousStates = state,
-            Signer = SignerAddress(),
-            Random = random,
-            Rehearsal = false,
-            BlockIndex = 1,
-        });
+        state = action.Execute(
+            new DummyActionContext
+            {
+                PreviousStates = state,
+                Signer = SignerAddress(),
+                Random = random,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }
+        );
 
         var afterRootStateEncoded = state.GetState(SignerAddress());
 

--- a/backend/app/Savor22b/Helpers/CsvDataHelper.cs
+++ b/backend/app/Savor22b/Helpers/CsvDataHelper.cs
@@ -17,6 +17,7 @@ public static class CsvDataHelper
     private static ImmutableList<KitchenEquipmentCategory> kitchenEquipmentCategoryList;
     private static ImmutableList<Item> itemList;
     private static ImmutableList<Village> villageList;
+    private static ImmutableList<VillageCharacteristic> villageCharacteristicList;
 
     public static void Initialize(string csvDataPath)
     {
@@ -308,4 +309,35 @@ public static class CsvDataHelper
     }
 
     #endregion village
+
+
+    #region villageCharacteristic
+
+    private static void initVillageCharacteristic()
+    {
+        if (villageCharacteristicList == null)
+        {
+            CsvParser<VillageCharacteristic> csvParser = new CsvParser<VillageCharacteristic>();
+            var csvPath = GetCSVDataPath(CsvDataFileNames.VillageCharacteristics);
+            villageCharacteristicList = csvParser.ParseCsv(csvPath).ToImmutableList();
+        }
+    }
+
+    public static ImmutableList<VillageCharacteristic> GetVillageCharacteristicCSVData()
+    {
+        initVillageCharacteristic();
+
+        return villageCharacteristicList;
+    }
+
+    public static VillageCharacteristic? GetVillageCharacteristicByVillageId(int villageId)
+    {
+        initVillageCharacteristic();
+
+        return villageCharacteristicList.Find(
+            characteristic => characteristic.VillageId == villageId
+        );
+    }
+
+    #endregion villageCharacteristic
 }

--- a/backend/app/Savor22b/Model/VillageCharacteristic.cs
+++ b/backend/app/Savor22b/Model/VillageCharacteristic.cs
@@ -1,9 +1,10 @@
+using System.Collections.Immutable;
+
 namespace Savor22b.Model;
 
 public class VillageCharacteristic
 {
-    // ID,VillageID,AvailableSeedID
     public int Id { get; set; }
     public int VillageId { get; set; }
-    public string AvailableSeedId { get; set; }
+    public ImmutableList<int> AvailableSeedIdList { get; set; }
 }

--- a/resources/savor22b/tabledata/village_characteristics.csv
+++ b/resources/savor22b/tabledata/village_characteristics.csv
@@ -1,3 +1,3 @@
-ID,VillageID,AvailableSeedID
+ID,VillageID,AvailableSeedIDList
 1,1,1;2;3;4;5;6;7;9;10
 2,2,1;2;3;4;8;9;10;11;12;13


### PR DESCRIPTION
- 기존엔 랜덤 종자 생성 아이템을 사용했을 경우, 나올 수 있는 모든 경우의 종자가 가능했습니다.
- 하지만 이제는 2.0 버전으로 달라졌습니다.
- 마을의 AvaliableSeedList에 포함된 종자만 생성될 수 있도록 기능을 수정했습니다.
  - 기본적으로 현재 거주하고 있는 마을이 존재 해야만 종자 관련 액션을 할 수 있기때문에
  - 모든 작업은 이것이 전제입니다.
