### PR TITLE
[SVR-123]재료 생성 버튼 연결

### DIFF
--- a/frontend/Savor-22b/Assets/Resources/Prefabs/InventorySeed.prefab
+++ b/frontend/Savor-22b/Assets/Resources/Prefabs/InventorySeed.prefab
@@ -175,6 +175,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 89e904228d0524eebbff9d8903d0fb1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  svrReference: {fileID: 11400000, guid: 38e7c9c0fffe34996ae8cf5c6c4417ee, type: 2}
+  privateKeyHex: eda6ef63ae945cd15572fcf7d6635a8b3f8d86e85b57a353b482bc82c7fd2ad4
   seedStateId: {fileID: 8778449230615227800}
   seedId: {fileID: 8778449230942835930}
   IngredientCreateButton: {fileID: 8778449231450303529}

--- a/frontend/Savor-22b/Assets/Scripts/Inventory/ItemInventory.cs
+++ b/frontend/Savor-22b/Assets/Scripts/Inventory/ItemInventory.cs
@@ -147,7 +147,6 @@ public class ItemInventory : MonoBehaviour
     public async void CreateNewSeed()
     {
         GraphApi.Query query = svrReference.GetQueryByName("CreateNewSeed", GraphApi.Query.Type.Mutation);
-        query.SetArgs(new { address });
         query.SetArgs(new { privateKeyHex });
         UnityWebRequest request = await svrReference.Post(query);
     }

--- a/frontend/Savor-22b/Assets/Scripts/Inventory/SeedUI.cs
+++ b/frontend/Savor-22b/Assets/Scripts/Inventory/SeedUI.cs
@@ -1,9 +1,16 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using GraphQlClient.Core;
+using GraphQlClient.EventCallbacks;
+using UnityEngine.Networking;
 
 public class SeedUI : MonoBehaviour
 {
+    [Header("API")]
+    public GraphApi svrReference;
+    public string privateKeyHex;
+
     public Text seedStateId;
     public Text seedId;
 
@@ -17,9 +24,11 @@ public class SeedUI : MonoBehaviour
         SetIngredientCreateButton(seed.stateId);
     }
 
-    public void CreateIngredient(Guid seedStateId)
+    public async void CreateIngredient(Guid seedStateId)
     {
-        Debug.Log("Create ingredient");
+        GraphApi.Query query = svrReference.GetQueryByName(QueryNames.CREATE_INGREDIENT, GraphApi.Query.Type.Mutation);
+        query.SetArgs(new { privateKeyHex, seedStateId });
+        UnityWebRequest request = await svrReference.Post(query);
     }
 
     public void SetIngredientCreateButton(Guid seedStateId)

--- a/frontend/Savor-22b/Assets/Scripts/Models/QueryNames.cs
+++ b/frontend/Savor-22b/Assets/Scripts/Models/QueryNames.cs
@@ -3,4 +3,5 @@ using System;
 public static class QueryNames
 {
     public static readonly string GET_ALL_RECIPE = "GetAllRecipe";
+    public static readonly string CREATE_INGREDIENT = "CreateNewIngredient";
 }


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
출력된 시드 프리팹 안의 재료 생성 버튼이 동작하도록 수정했습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
인벤토리 내의 seed state id를 토대로 재료를 생성할 수 있도록 합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="458" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/fc71b5e1-99ed-4a1d-80b3-51340afafd59">

SeedUI.cs 내에 seedStateId를 전달할 수 있도록 되어있기 때문에 뮤테이션을 해당 코드 내에서 실행할 수 있도록 API를 추가하였습니다.
privateKeyHex를 에디터 내에서 입력 받습니다.

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
ItemInventory 내에 시드 생성 코드가 변경된 것은, 변수 설정법이 잘못된 것을 발견해서 한줄 지운 것 뿐입니다.

