### PR TITLE
Fix initial seeds in PlaceUserHouseAction

### DIFF
--- a/backend/app/Savor22b.Tests/Action/PlaceUserHouseActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/PlaceUserHouseActionTests.cs
@@ -57,6 +57,10 @@ public class PlaceUserHouseActionTests : ActionTests
         );
 
         Assert.Equal(100, rootState.InventoryState.SeedStateList.Count);
+        Assert.All(
+            rootState.InventoryState.SeedStateList,
+            (seed) => Assert.True(seed.SeedID >= 1 && seed.SeedID <= 13)
+        );
         Assert.Equal(
             Enumerable.Repeat(10, 6).ToImmutableList(),
             rootState.InventoryState.KitchenEquipmentStateList.Aggregate(

--- a/backend/app/Savor22b/Action/PlaceUserHouseAction.cs
+++ b/backend/app/Savor22b/Action/PlaceUserHouseAction.cs
@@ -143,7 +143,7 @@ public class PlaceUserHouseAction : SVRAction
             for (int i = 0; i < 100; i++)
             {
                 inventoryState = inventoryState.AddSeed(
-                    new SeedState(ctx.Random.GenerateRandomGuid(), ctx.Random.Next() % 13)
+                    new SeedState(ctx.Random.GenerateRandomGuid(), ctx.Random.Next() % 13 + 1)
                 );
             }
 


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
데모용으로 PlaceUserHouseAction 처음 돌려서 씨앗 배분받을때 seedId 잘못들어가던 버그 수정,,,

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
