### PR TITLE
SVR-256: 집 선택 화면 스크롤 바 적용

### DIFF
--- a/frontend/Savor-22b/scenes/select_house.tscn
+++ b/frontend/Savor-22b/scenes/select_house.tscn
@@ -102,17 +102,23 @@ theme_override_constants/margin_bottom = 20
 layout_mode = 2
 color = Color(0, 0, 0, 1)
 
-[node name="HomeGridContainer" type="GridContainer" parent="MarginContainer/Background"]
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/Background"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 50.0
-offset_top = 50.0
-offset_right = -50.0
-offset_bottom = -50.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 50
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/Background/MarginContainer"]
+layout_mode = 2
+
+[node name="HomeGridContainer" type="GridContainer" parent="MarginContainer/Background/MarginContainer/ScrollContainer"]
+layout_mode = 2
 theme_override_constants/h_separation = 100
 theme_override_constants/v_separation = 50
 columns = 5

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -43,6 +43,7 @@ var user_state: Dictionary
 
 var selected_house_index := 0
 var selected_village_capacity := 0
+var selected_village_width := 0
 
 #func _ready():
 	#var json = JSON.new()

--- a/frontend/Savor-22b/scripts/scenes/select_house.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_house.gd
@@ -4,19 +4,20 @@ const SELECT_HOUSE_BUTTON = preload("res://ui/house_slot_button.tscn")
 const SLOT_IS_FULL = preload("res://ui/notice_popup.tscn")
 
 @onready var noticepopup = $MarginContainer/Background/Noticepopup
-@onready var gridcontainer = $MarginContainer/Background/HomeGridContainer
+@onready var gridcontainer = $MarginContainer/Background/MarginContainer/ScrollContainer/HomeGridContainer
 
 var houses = []
 
 func _ready():
 	print("select_house scene ready")
-	#var size = SceneContext.selected_village_capacity
+	var size = SceneContext.selected_village_capacity
 	testinput()
 	
-	var size = 12
+	gridcontainer.columns = SceneContext.selected_village_width
+	
 	
 	for i in range(size):
-		var house = {"x" : size, "y" : 0, "owner" : "none"}
+		var house = {"x" : i, "y" : 0, "owner" : "none"}
 		houses.append(house)
 		var button = SELECT_HOUSE_BUTTON.instantiate()
 		button.set_house(house)

--- a/frontend/Savor-22b/scripts/scenes/select_village.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_village.gd
@@ -33,5 +33,6 @@ func _on_start_button_button_down():
 	var village = SceneContext.get_selected_village()
 	var capacity = village["height"] * village["width"]
 	SceneContext.selected_village_capacity = capacity
+	SceneContext.selected_village_width = village["width"]
 	
 	get_tree().change_scene_to_file("res://scenes/select_house.tscn")


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 집 선택 화면을 전부 표시하기 위해 크기만큼 스크롤되는 화면으로 만들었습니다.
- 마을 면적에 해당하는 만큼 클롯을 표시합니다.
- 그리드 너비를 마을 너비로 설정하여 직관적으로 표시합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="950" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/e8224388-d758-4f4d-8492-e50a2e032d39">
- 예시 사진에서는 선택된 마을의 너비가 7이라 가로 스크롤도 제대로 적용 된 모습입니다.
