### PR TITLE
SVR-257: 집 위치를 정확히 표현하는 좌표 넣기

### DIFF
--- a/frontend/Savor-22b/scenes/testpanel/test_panel.gd
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.gd
@@ -1,0 +1,14 @@
+extends Control
+
+
+func _ready():
+	pass # Replace with function body.
+
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_T:
+			get_tree().change_scene_to_file("res://scenes/testpanel/test_panel.tscn")
+			print("Test panel open")
+
+func _on_village_view_pressed():
+	get_tree().change_scene_to_file("res://village_view/VillageView.tscn")

--- a/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=2 format=3 uid="uid://bdfibt7fw8oj8"]
+
+[ext_resource type="Script" path="res://scenes/testpanel/test_panel.gd" id="1_5v2p1"]
+
+[node name="TestPanel" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_5v2p1")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -1.0
+offset_bottom = -1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Background"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 50
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
+
+[node name="GridContainer" type="GridContainer" parent="Background/MarginContainer"]
+layout_mode = 2
+theme_override_constants/h_separation = 300
+theme_override_constants/v_separation = 300
+columns = 5
+
+[node name="VillageView" type="Button" parent="Background/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "VillageView.tscn"
+
+[connection signal="pressed" from="Background/MarginContainer/GridContainer/VillageView" to="." method="_on_village_view_pressed"]

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -44,6 +44,7 @@ var user_state: Dictionary
 var selected_house_index := 0
 var selected_village_capacity := 0
 var selected_village_width := 0
+var selected_village_height := 0
 
 #func _ready():
 	#var json = JSON.new()

--- a/frontend/Savor-22b/scripts/scenes/select_house.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_house.gd
@@ -8,21 +8,40 @@ const SLOT_IS_FULL = preload("res://ui/notice_popup.tscn")
 
 var houses = []
 
+
 func _ready():
 	print("select_house scene ready")
 	var size = SceneContext.selected_village_capacity
 	testinput()
+
 	
 	gridcontainer.columns = SceneContext.selected_village_width
 	
+	var startxloc = -(( SceneContext.selected_village_width - 1 ) / 2)
+	var startyloc = (SceneContext.selected_village_height -1 ) / 2
+	var endxloc = ( SceneContext.selected_village_width - 1 ) / 2
+	
+	print("startxloc: %s" % startxloc)
+	print("startyloc: %s" % startyloc)
+	print("endxloc: %s" % endxloc)
+
+	
 	
 	for i in range(size):
-		var house = {"x" : i, "y" : 0, "owner" : "none"}
+		var house = {"x" : startxloc, "y" : startyloc, "owner" : "none"}
 		houses.append(house)
 		var button = SELECT_HOUSE_BUTTON.instantiate()
 		button.set_house(house)
 		button.button_down.connect(button_selected)
-		gridcontainer.add_child(button)
+		gridcontainer.add_child(button)		
+		
+		if(startxloc == endxloc):
+			startyloc -= 1
+			startxloc = -(( SceneContext.selected_village_width - 1 ) / 2)
+		else:
+			startxloc += 1
+
+
 	
 	#for house in houses:
 		#var button = SELECT_HOUSE_BUTTON.instantiate()
@@ -54,7 +73,6 @@ func _on_button_pressed():
 func _on_build_button_button_down():
 	print_notice()
 
-	
 	
 func print_notice():
 	var box = SLOT_IS_FULL.instantiate()

--- a/frontend/Savor-22b/scripts/scenes/select_village.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_village.gd
@@ -34,5 +34,6 @@ func _on_start_button_button_down():
 	var capacity = village["height"] * village["width"]
 	SceneContext.selected_village_capacity = capacity
 	SceneContext.selected_village_width = village["width"]
-	
+	SceneContext.selected_village_height = village["height"]
+		
 	get_tree().change_scene_to_file("res://scenes/select_house.tscn")


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 추후 집 생성에 필요한 집 위치 좌표를 슬롯 생성 시에 슬롯에 넣습니다.


# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 과거에는 instantiate()를 한 후에 슬롯에 정보가 아무것도 없는 빈 house 딕셔너리가 들어갔다면 지금은 생성되는 순서에 따라서 슬롯에 좌표를 넣습니다.
- 좌표는 너비와 높이를 기준으로 한 그래프와 동일한 위치가 되도록 합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="679" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/4c103e1a-52ce-4a33-908c-5c2dbbc6ec0f">

정가운데에 0, 0 인 슬롯이 제대로 잘 보이는 모습입니다.

