### PR TITLE
SVR-176: 집 설치 API 작업

### DIFF
--- a/frontend/Savor-22b/project.godot
+++ b/frontend/Savor-22b/project.godot
@@ -22,6 +22,7 @@ GlobalSigner="*res://scripts/sign/Signer.gd"
 SvrGqlClient="*res://gql/svr_gql_client.gd"
 SceneContext="*res://scripts/global/scene_context.gd"
 GlobalInventory="*res://scripts/global/inventory.gd"
+Intro="*res://scripts/scenes/intro.gd"
 
 [display]
 

--- a/frontend/Savor-22b/scenes/select_house.tscn
+++ b/frontend/Savor-22b/scenes/select_house.tscn
@@ -88,6 +88,31 @@ grow_vertical = 2
 theme_override_font_sizes/font_size = 70
 text = "Build"
 
+[node name="RefreshButtonContainer" type="ColorRect" parent="BottomMenuMarginContainer/Control"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 70.0
+offset_top = -50.0
+offset_right = 430.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="RefreshButton" type="Button" parent="BottomMenuMarginContainer/Control/RefreshButtonContainer"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 70
+text = "Refresh"
+
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 0
 offset_top = 140.0
@@ -132,3 +157,5 @@ offset_bottom = 340.0
 
 [connection signal="pressed" from="TopMenuMarginContainer/Control/HomeButtonContainer/Button" to="." method="_on_button_pressed"]
 [connection signal="button_down" from="BottomMenuMarginContainer/Control/BuildButtonContainer/BuildButton" to="." method="_on_build_button_button_down"]
+[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_build_button_button_down"]
+[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_refresh_button_button_down"]

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -42,6 +42,7 @@ var selected_village_index := 0
 var user_state: Dictionary
 
 var selected_house_index := 0
+var selected_house_location: Dictionary
 var selected_village_capacity := 0
 var selected_village_width := 0
 var selected_village_height := 0

--- a/frontend/Savor-22b/scripts/scenes/select_house.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_house.gd
@@ -15,9 +15,6 @@ func _ready():
 	print("select_house scene ready")
 	var size = SceneContext.selected_village_capacity
 	
-	print(houses)
-
-	
 	gridcontainer.columns = SceneContext.selected_village_width
 	
 	var startxloc = -(( SceneContext.selected_village_width - 1 ) / 2)
@@ -45,8 +42,7 @@ func _ready():
 			if h1["x"] == h2["x"] and h1["y"] == h2["y"]:
 				h2["owner"] = h1["owner"]
 			
-	for slot in houses:
-		var info = slot
+	for info in houses:
 		var button = SELECT_HOUSE_BUTTON.instantiate()
 		button.set_house(info)
 		button.button_down.connect(button_selected)
@@ -55,7 +51,7 @@ func _ready():
 
 func button_selected(house_index):
 	var format_string1 = "house button down: %s"
-	var format_string2 = "location: %s"
+	var format_string2 = "selected slot location: %s"
 	print(format_string1 % house_index)
 	print(format_string2 % houses[house_index])	
 	SceneContext.selected_house_index = house_index
@@ -71,6 +67,7 @@ func _on_build_button_button_down():
 		print_notice()
 	else:
 		build_house()
+
 
 	
 func print_notice():
@@ -103,7 +100,25 @@ func build_house():
 	add_child(query_executor)
 	query_executor.run({})
 
+
+
+func _on_refresh_button_button_down():
+	Intro._query_villages()
 	
+	for child in gridcontainer.get_children():
+		child.queue_free()
+	
+	for h0 in houses:
+		h0["owner"] = "none"
 
-
-
+	existhouses = SceneContext.get_selected_village()["houses"]
+	for h1 in existhouses:
+		for h2 in houses:
+			if h1["x"] == h2["x"] and h1["y"] == h2["y"]:
+				h2["owner"] = h1["owner"]
+			
+	for info in houses:
+		var button = SELECT_HOUSE_BUTTON.instantiate()
+		button.set_house(info)
+		button.button_down.connect(button_selected)
+		gridcontainer.add_child(button)

--- a/frontend/Savor-22b/scripts/scenes/select_house.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_house.gd
@@ -2,17 +2,20 @@ extends Control
 
 const SELECT_HOUSE_BUTTON = preload("res://ui/house_slot_button.tscn")
 const SLOT_IS_FULL = preload("res://ui/notice_popup.tscn")
+const Gql_query = preload("res://gql/query.gd")
 
 @onready var noticepopup = $MarginContainer/Background/Noticepopup
 @onready var gridcontainer = $MarginContainer/Background/MarginContainer/ScrollContainer/HomeGridContainer
 
 var houses = []
+var existhouses = SceneContext.get_selected_village()["houses"]
 
 
 func _ready():
 	print("select_house scene ready")
 	var size = SceneContext.selected_village_capacity
-	testinput()
+	
+	print(houses)
 
 	
 	gridcontainer.columns = SceneContext.selected_village_width
@@ -26,14 +29,10 @@ func _ready():
 	print("endxloc: %s" % endxloc)
 
 	
-	
+	#create blank slots
 	for i in range(size):
 		var house = {"x" : startxloc, "y" : startyloc, "owner" : "none"}
 		houses.append(house)
-		var button = SELECT_HOUSE_BUTTON.instantiate()
-		button.set_house(house)
-		button.button_down.connect(button_selected)
-		gridcontainer.add_child(button)		
 		
 		if(startxloc == endxloc):
 			startyloc -= 1
@@ -41,29 +40,26 @@ func _ready():
 		else:
 			startxloc += 1
 
-
-	
-	#for house in houses:
-		#var button = SELECT_HOUSE_BUTTON.instantiate()
-		#print(house)
-		#button.set_house(house)
-		#button.button_down.connect(button_selected)
-		#
-		#gridcontainer.add_child(button)
-	
-	pass
-
-func testinput():
-	houses.append({"x" : 12, "y" : 23, "owner" : "doge"})
-	houses.append({"x" : 13, "y" : 55, "owner" : "hampter"})
-	houses.append({"x" : 14, "y" : 78, "owner" : "kirby"})
-	
+	for h1 in existhouses:
+		for h2 in houses:
+			if h1["x"] == h2["x"] and h1["y"] == h2["y"]:
+				h2["owner"] = h1["owner"]
+			
+	for slot in houses:
+		var info = slot
+		var button = SELECT_HOUSE_BUTTON.instantiate()
+		button.set_house(info)
+		button.button_down.connect(button_selected)
+		gridcontainer.add_child(button)
 
 
 func button_selected(house_index):
-	var format_string = "house button down: %s"
-	print(format_string % house_index)
+	var format_string1 = "house button down: %s"
+	var format_string2 = "location: %s"
+	print(format_string1 % house_index)
+	print(format_string2 % houses[house_index])	
 	SceneContext.selected_house_index = house_index
+	SceneContext.selected_house_location = houses[house_index]
 
 
 func _on_button_pressed():
@@ -71,9 +67,43 @@ func _on_button_pressed():
 
 
 func _on_build_button_button_down():
-	print_notice()
+	if (SceneContext.selected_house_location["owner"] != "none"):
+		print_notice()
+	else:
+		build_house()
 
 	
 func print_notice():
 	var box = SLOT_IS_FULL.instantiate()
 	noticepopup.add_child(box)
+	
+func build_house():
+	var gql_query = Gql_query.new()
+	var query_string = gql_query.place_house_query_format.format([
+			"\"%s\"" % GlobalSigner.signer.GetPublicKey(),
+			SceneContext.get_selected_village()["id"],
+			SceneContext.selected_house_location.x,
+			SceneContext.selected_house_location.y], "{}")
+	print(query_string)
+	
+	var query_executor = SvrGqlClient.raw(query_string)
+	query_executor.graphql_response.connect(func(data):
+		print("gql response: ", data)
+		var unsigned_tx = data["data"]["createAction_PlaceUserHouse"]
+		print("unsigned tx: ", unsigned_tx)
+		var signature = GlobalSigner.sign(unsigned_tx)
+		print("signed tx: ", signature)
+		var mutation_executor = SvrGqlClient.raw_mutation(gql_query.stage_tx_query_format % [unsigned_tx, signature])
+		mutation_executor.graphql_response.connect(func(data):
+			print("mutation res: ", data)
+		)
+		add_child(mutation_executor)
+		mutation_executor.run({})
+	)
+	add_child(query_executor)
+	query_executor.run({})
+
+	
+
+
+

--- a/frontend/Savor-22b/scripts/scenes/select_village.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_village.gd
@@ -7,6 +7,8 @@ const SELECT_VILLAGE_VILLAGE_BUTTON = preload("res://ui/select_village_village_b
 
 func _ready():
 	print("select_village scene ready")
+	Intro._query_villages()
+	_update_village_info_label()
 	for village in SceneContext.villages:
 		var button = SELECT_VILLAGE_VILLAGE_BUTTON.instantiate()
 		button.set_village(village)

--- a/frontend/Savor-22b/ui/house_slot_button.gd
+++ b/frontend/Savor-22b/ui/house_slot_button.gd
@@ -5,6 +5,7 @@ signal button_down(child_index: int)
 @onready var button = $Button
 
 var house: Dictionary
+var existhouses = SceneContext.get_selected_village()["houses"]
 
 var format_string = "%s 
 (x = %d, y = %d)"
@@ -15,13 +16,18 @@ func _ready():
 func _update_button():
 	if button == null:
 		return
-	
+		
 	button.text = format_string % [ house.owner, house.x, house.y ]
 	
 
 func set_house(house: Dictionary):
 	self.house = house
 	_update_button()
+	
+func update_owner():
+	for h1 in existhouses:
+		if h1["x"] == house["x"] and h1["y"] == house["y"]:
+			house["owner"] = h1["owner"]
 
 
 

--- a/frontend/Savor-22b/ui/house_slot_button.tscn
+++ b/frontend/Savor-22b/ui/house_slot_button.tscn
@@ -6,7 +6,7 @@
 
 [node name="HouseSlotButton" type="ColorRect"]
 z_as_relative = false
-custom_minimum_size = Vector2(200, 150)
+custom_minimum_size = Vector2(400, 150)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -33,5 +33,6 @@ theme_override_styles/pressed = SubResource("StyleBoxEmpty_phxol")
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_phxol")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_phxol")
 text = "집 설치 가능"
+text_overrun_behavior = 3
 
 [connection signal="button_down" from="Button" to="." method="_on_button_button_down"]


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 집을 설치 가능합니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 현재 마을의 집 상태를 표시합니다.
- 빈 슬롯을 누르고 빌드하면 집이 설치됩니다.
- 기존에 있는 자리의 경우 집이 설치되지 않고 팝업을 띄웁니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="954" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/5e080401-f151-4129-82dd-70fcf7cb2bda">

- build를 누르면 집 설치가 진행됨
- 현재 동일한 키로 집 설치를 진행하는데 집은 1개만 설치되므로 다른 곳에 설치 시 집이 이동됨
- 설치된 집은 소유자가 표시됨
- 설치됨을 게임 내에서 확인할 수 있도록 새로고침 버튼을 추가
- 기존 빈 슬롯을 만드는 코드에서 집을 로드할 수 있도록 로직을 수정

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
- 쿼리형식으로 처리하다보니 구독이 없어서 새로고침을 추가했습니다만 반영되는데 시간이 좀 걸립니다.
- 어쩌다보니 기존 집을 같이 표현할 수 있게되었는데 동일한 목표의 티켓이 있어서 sub-tasks로 옮겼습니다.
