### PR TITLE
SVR-266: 밭 관련 UI 제작

### DIFF
--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://vy5r0acj44oh"]
+[gd_scene load_steps=3 format=3 uid="uid://vy5r0acj44oh"]
 
 [ext_resource type="Script" path="res://scripts/scenes/farm.gd" id="1_q2tum"]
+[ext_resource type="PackedScene" uid="uid://c0qm0ud7mwmwb" path="res://ui/farm_slot_button.tscn" id="2_fjqrk"]
 
 [node name="Farm" type="Control"]
 layout_mode = 3
@@ -48,16 +49,53 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 200
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
 
-[node name="GridContainer" type="GridContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer"]
 layout_mode = 2
-theme_override_constants/h_separation = 10
-theme_override_constants/v_separation = 10
-columns = 2
+theme_override_constants/separation = 100
+
+[node name="Left" type="VBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 20
+
+[node name="Slot1" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot2" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot3" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot4" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot5" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Right" type="VBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Slot6" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot7" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot8" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot9" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
+
+[node name="Slot10" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
+layout_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2

--- a/frontend/Savor-22b/scenes/village_view.tscn
+++ b/frontend/Savor-22b/scenes/village_view.tscn
@@ -1,15 +1,15 @@
-[gd_scene load_steps=2 format=3 uid="uid://dy1e0tpo1lsby"]
+[gd_scene load_steps=2 format=3 uid="uid://wkyffjkvp7av"]
 
-[ext_resource type="Script" path="res://scripts/scenes/select_house.gd" id="1_012c4"]
+[ext_resource type="Script" path="res://scripts/scenes/village_view.gd" id="1_oar4x"]
 
-[node name="SelectHouse" type="Control"]
+[node name="VillageView" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_012c4")
+script = ExtResource("1_oar4x")
 
 [node name="Background" type="ColorRect" parent="."]
 layout_mode = 1
@@ -40,7 +40,7 @@ offset_bottom = 100.0
 size_flags_horizontal = 4
 color = Color(0, 0, 0, 1)
 
-[node name="Button" type="Button" parent="TopMenuMarginContainer/Control/HomeButtonContainer"]
+[node name="HomeButton" type="Button" parent="TopMenuMarginContainer/Control/HomeButtonContainer"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -49,24 +49,6 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 70
 text = "Home"
-
-[node name="BackButtonContainer2" type="ColorRect" parent="TopMenuMarginContainer/Control"]
-layout_mode = 0
-offset_left = 540.0
-offset_right = 950.0
-offset_bottom = 100.0
-size_flags_horizontal = 4
-color = Color(0, 0, 0, 1)
-
-[node name="BackButton" type="Button" parent="TopMenuMarginContainer/Control/BackButtonContainer2"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_font_sizes/font_size = 70
-text = "Back"
 
 [node name="BottomMenuMarginContainer" type="MarginContainer" parent="."]
 layout_mode = 0
@@ -81,22 +63,22 @@ theme_override_constants/margin_bottom = 20
 [node name="Control" type="Control" parent="BottomMenuMarginContainer"]
 layout_mode = 2
 
-[node name="BuildButtonContainer" type="ColorRect" parent="BottomMenuMarginContainer/Control"]
+[node name="EnterButtonContainer" type="ColorRect" parent="BottomMenuMarginContainer/Control"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = 570.0
+offset_left = 50.0
 offset_top = -50.0
-offset_right = 930.0
+offset_right = 950.0
 offset_bottom = 50.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
-[node name="BuildButton" type="Button" parent="BottomMenuMarginContainer/Control/BuildButtonContainer"]
+[node name="EnterButton" type="Button" parent="BottomMenuMarginContainer/Control/EnterButtonContainer"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -104,24 +86,24 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 70
-text = "Build"
+text = "Enter Selected Dungeon"
 
-[node name="RefreshButtonContainer" type="ColorRect" parent="BottomMenuMarginContainer/Control"]
+[node name="BuildMenuButtonContainer" type="ColorRect" parent="BottomMenuMarginContainer/Control"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = 70.0
+offset_left = -390.0
 offset_top = -50.0
-offset_right = 430.0
+offset_right = 30.0
 offset_bottom = 50.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
-[node name="RefreshButton" type="Button" parent="BottomMenuMarginContainer/Control/RefreshButtonContainer"]
+[node name="BuildMenuButton" type="Button" parent="BottomMenuMarginContainer/Control/BuildMenuButtonContainer"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -129,7 +111,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 70
-text = "Refresh"
+text = "Build house"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 0
@@ -173,8 +155,6 @@ offset_top = 300.0
 offset_right = 640.0
 offset_bottom = 340.0
 
-[connection signal="pressed" from="TopMenuMarginContainer/Control/HomeButtonContainer/Button" to="." method="_on_button_pressed"]
-[connection signal="button_down" from="TopMenuMarginContainer/Control/BackButtonContainer2/BackButton" to="." method="_on_back_button_button_down"]
-[connection signal="button_down" from="BottomMenuMarginContainer/Control/BuildButtonContainer/BuildButton" to="." method="_on_build_button_button_down"]
-[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_build_button_button_down"]
-[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_refresh_button_button_down"]
+[connection signal="button_down" from="TopMenuMarginContainer/Control/HomeButtonContainer/HomeButton" to="." method="_on_home_button_button_down"]
+[connection signal="button_down" from="BottomMenuMarginContainer/Control/EnterButtonContainer/EnterButton" to="." method="_on_enter_button_button_down"]
+[connection signal="button_down" from="BottomMenuMarginContainer/Control/BuildMenuButtonContainer/BuildMenuButton" to="." method="_on_build_menu_button_button_down"]

--- a/frontend/Savor-22b/scripts/scenes/select_house.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_house.gd
@@ -57,11 +57,10 @@ func button_selected(house_index):
 	SceneContext.selected_house_index = house_index
 	SceneContext.selected_house_location = houses[house_index]
 
-	
+	#Toggle mode
 	for slot in gridcontainer.get_children():
-		print(slot.get_index())
 		if(slot.get_index() != house_index):
-			slot.disable_button()
+			slot.disable_button_selected()
 
 
 
@@ -129,3 +128,7 @@ func _on_refresh_button_button_down():
 		button.set_house(info)
 		button.button_down.connect(button_selected)
 		gridcontainer.add_child(button)
+
+
+func _on_back_button_button_down():
+	get_tree().change_scene_to_file("res://scenes/village_view.tscn")

--- a/frontend/Savor-22b/scripts/scenes/select_village.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_village.gd
@@ -38,4 +38,4 @@ func _on_start_button_button_down():
 	SceneContext.selected_village_width = village["width"]
 	SceneContext.selected_village_height = village["height"]
 		
-	get_tree().change_scene_to_file("res://scenes/select_house.tscn")
+	get_tree().change_scene_to_file("res://scenes/village_view.tscn")

--- a/frontend/Savor-22b/scripts/scenes/village_view.gd
+++ b/frontend/Savor-22b/scripts/scenes/village_view.gd
@@ -1,0 +1,80 @@
+extends Control
+
+const SELECT_HOUSE_BUTTON = preload("res://ui/house_slot_button.tscn")
+
+@onready var gridcontainer = $MarginContainer/Background/MarginContainer/ScrollContainer/HomeGridContainer
+
+var houses = []
+var existhouses = SceneContext.get_selected_village()["houses"]
+
+
+func _ready():
+	print("village view scene ready")
+	var size = SceneContext.selected_village_capacity
+	
+	gridcontainer.columns = SceneContext.selected_village_width
+	
+	var startxloc = -(( SceneContext.selected_village_width - 1 ) / 2)
+	var startyloc = (SceneContext.selected_village_height -1 ) / 2
+	var endxloc = ( SceneContext.selected_village_width - 1 ) / 2
+	
+	print("startxloc: %s" % startxloc)
+	print("startyloc: %s" % startyloc)
+	print("endxloc: %s" % endxloc)
+
+	
+	#create blank slots
+	for i in range(size):
+		var house = {"x" : startxloc, "y" : startyloc, "owner" : "none"}
+		houses.append(house)
+		
+		if(startxloc == endxloc):
+			startyloc -= 1
+			startxloc = -(( SceneContext.selected_village_width - 1 ) / 2)
+		else:
+			startxloc += 1
+
+	for h1 in existhouses:
+		for h2 in houses:
+			if h1["x"] == h2["x"] and h1["y"] == h2["y"]:
+				h2["owner"] = h1["owner"]
+			
+	for info in houses:
+		var button = SELECT_HOUSE_BUTTON.instantiate()
+		button.set_house(info)
+		button.button_down.connect(button_selected)
+		gridcontainer.add_child(button)
+		
+	disable_buttons()
+
+
+func button_selected(house_index):
+	var format_string1 = "house button down: %s"
+	var format_string2 = "selected slot location: %s"
+	print(format_string1 % house_index)
+	print(format_string2 % houses[house_index])	
+	SceneContext.selected_house_index = house_index
+	SceneContext.selected_house_location = houses[house_index]
+
+	#Toggle mode
+	for slot in gridcontainer.get_children():
+		if(slot.get_index() != house_index):
+			slot.disable_button_selected()
+
+
+func disable_buttons():
+	print("button all disabled")
+	for slot in gridcontainer.get_children():
+		slot.disable_button()
+
+
+func _on_home_button_button_down():
+	get_tree().change_scene_to_file("res://scenes/select_village.tscn")
+
+func _on_build_menu_button_button_down():
+	get_tree().change_scene_to_file("res://scenes/select_house.tscn")
+
+
+func _on_enter_button_button_down():
+	pass # Replace with function body.
+

--- a/frontend/Savor-22b/ui/farm_install_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_install_popup.tscn
@@ -1,0 +1,64 @@
+[gd_scene load_steps=3 format=3 uid="uid://kttsr2bn7o31"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1w3ox"]
+bg_color = Color(0.866667, 0.498039, 0.215686, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0, 0, 0, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6tw4s"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="ColorRect" type="Panel"]
+offset_right = 400.0
+offset_bottom = 300.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_1w3ox")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 20
+
+[node name="Title" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "   종자 심기"
+vertical_alignment = 1
+
+[node name="Text" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 35
+text = "   종자 심기"
+vertical_alignment = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_direction = 3
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Blank" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+
+[node name="Accept" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_6tw4s")
+text = "  확인  "
+
+[node name="Cancel" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_6tw4s")
+text = "  취소  "
+
+[node name="Blank" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2

--- a/frontend/Savor-22b/ui/farm_slot_button.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_button.tscn
@@ -1,20 +1,35 @@
-[gd_scene load_steps=2 format=3 uid="uid://c0qm0ud7mwmwb"]
+[gd_scene load_steps=3 format=3 uid="uid://c0qm0ud7mwmwb"]
 
 [ext_resource type="Script" path="res://ui/farm_slot_button.gd" id="1_vqq1f"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1e62"]
+bg_color = Color(0.866667, 0.498039, 0.215686, 1)
+
 [node name="FarmSlotButton" type="ColorRect"]
-custom_minimum_size = Vector2(2.08165e-12, 200)
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
-size_flags_vertical = 0
+size_flags_vertical = 2
 script = ExtResource("1_vqq1f")
 
-[node name="Button" type="Button" parent="."]
+[node name="V" type="VBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="Button" type="Button" parent="V"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_b1e62")
 text = "[벼] 자라는 중
 [N 블록 남음]"

--- a/frontend/Savor-22b/ui/house_slot_button.gd
+++ b/frontend/Savor-22b/ui/house_slot_button.gd
@@ -29,9 +29,13 @@ func update_owner():
 		if h1["x"] == house["x"] and h1["y"] == house["y"]:
 			house["owner"] = h1["owner"]
 
-func disable_button():
+func disable_button_selected():
 	if(button.button_pressed):
 		button.button_pressed = false
+		
+
+func disable_button():
+	button.disabled = true
 
 
 func _on_button_button_down():

--- a/frontend/Savor-22b/ui/house_slot_button.tscn
+++ b/frontend/Savor-22b/ui/house_slot_button.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://djwsh8gou8pgp"]
+[gd_scene load_steps=5 format=3 uid="uid://djwsh8gou8pgp"]
 
 [ext_resource type="Script" path="res://ui/house_slot_button.gd" id="1_x2rs7"]
 
@@ -11,6 +11,9 @@ border_width_top = 10
 border_width_right = 10
 border_width_bottom = 10
 border_color = Color(1, 1, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4euop"]
+bg_color = Color(1, 1, 1, 0)
 
 [node name="HouseSlotButton" type="ColorRect"]
 z_as_relative = false
@@ -34,11 +37,12 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_colors/font_disabled_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 30
 theme_override_styles/normal = SubResource("StyleBoxEmpty_phxol")
 theme_override_styles/hover = SubResource("StyleBoxEmpty_phxol")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_uhfil")
-theme_override_styles/disabled = SubResource("StyleBoxEmpty_phxol")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_4euop")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_phxol")
 toggle_mode = true
 text = "집 설치 가능"


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 밭 표현에 필요한 UI를 제작했습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 밭을 표현하는 데 부족함이 없도록 UI 요소를 만듭니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="665" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/7bd857ca-ac77-442d-bc47-4151ac10cd7a">
<img width="423" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/4cfed35e-e9a9-4341-bbe3-ec3ff646d084">


- 씬 내부에 오브젝트 배치 수정

- 필요한 팝업 UI 생성

- 밭 표현 버튼 UI 수정

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
- 기존에 만들어두신 farm.tscn 쪽을 살려서 작업했습니다.
