### PR TITLE
SVR-178: 밭 전체 화면 및 밭 목록 확인 기능

### DIFF
--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -1,3 +1,5 @@
+[gd_scene load_steps=3 format=3 uid="uid://vy5r0acj44oh"]
+
 [ext_resource type="Script" path="res://scripts/scenes/farm.gd" id="1_q2tum"]
 [ext_resource type="PackedScene" uid="uid://c0qm0ud7mwmwb" path="res://ui/farm_slot_button.tscn" id="2_fjqrk"]
 [ext_resource type="PackedScene" uid="uid://bjcg2kocdfuua" path="res://ui/farm_slot_done.tscn" id="3_5vjtx"]

--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -1,11 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://vy5r0acj44oh"]
+[gd_scene load_steps=3 format=3 uid="uid://c10m1dv6u7ks7"]
 
 [ext_resource type="Script" path="res://scripts/scenes/farm.gd" id="1_q2tum"]
-[ext_resource type="PackedScene" uid="uid://c0qm0ud7mwmwb" path="res://ui/farm_slot_button.tscn" id="2_fjqrk"]
-[ext_resource type="PackedScene" uid="uid://bjcg2kocdfuua" path="res://ui/farm_slot_done.tscn" id="3_5vjtx"]
-[ext_resource type="PackedScene" uid="uid://bf6be56dhvlws" path="res://ui/farm_slot_empty.tscn" id="4_eb1ui"]
 [ext_resource type="PackedScene" uid="uid://kttsr2bn7o31" path="res://ui/farm_install_popup.tscn" id="5_ka4ym"]
-
 
 [node name="Farm" type="Control"]
 layout_mode = 3
@@ -17,7 +13,7 @@ grow_vertical = 2
 script = ExtResource("1_q2tum")
 metadata/_edit_horizontal_guides_ = [-309.0]
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="Background" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -25,7 +21,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MC" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -37,17 +33,17 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+[node name="HC" type="HBoxContainer" parent="MC"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="ColorRect" type="ColorRect" parent="MarginContainer/HBoxContainer"]
+[node name="CR" type="ColorRect" parent="MC/HC"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.7
 color = Color(0, 0, 0, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/ColorRect"]
+[node name="MC" type="MarginContainer" parent="MC/HC/CR"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -59,60 +55,26 @@ theme_override_constants/margin_top = 50
 theme_override_constants/margin_right = 50
 theme_override_constants/margin_bottom = 50
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer"]
+[node name="HC" type="HBoxContainer" parent="MC/HC/CR/MC"]
 layout_mode = 2
 theme_override_constants/separation = 100
 
-[node name="Left" type="VBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer"]
+[node name="Left" type="VBoxContainer" parent="MC/HC/CR/MC/HC"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 20
 
-
-[node name="FarmSlotButton" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
-layout_mode = 2
-
-[node name="FarmSlotButton2" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
-layout_mode = 2
-
-[node name="FarmSlotButton3" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("2_fjqrk")]
-layout_mode = 2
-
-[node name="FarmSlotDone" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("3_5vjtx")]
-layout_mode = 2
-
-[node name="FarmSlotDone2" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Left" instance=ExtResource("3_5vjtx")]
-
-layout_mode = 2
-
-[node name="Right" type="VBoxContainer" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer"]
+[node name="Right" type="VBoxContainer" parent="MC/HC/CR/MC/HC"]
 layout_mode = 2
 size_flags_horizontal = 3
-
 theme_override_constants/separation = 20
 
-[node name="FarmSlotButton" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("2_fjqrk")]
-layout_mode = 2
-
-[node name="FarmSlotEmpty" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("4_eb1ui")]
-layout_mode = 2
-
-[node name="FarmSlotEmpty2" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("4_eb1ui")]
-layout_mode = 2
-
-[node name="FarmSlotEmpty3" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("4_eb1ui")]
-layout_mode = 2
-
-[node name="FarmSlotEmpty4" parent="MarginContainer/HBoxContainer/ColorRect/MarginContainer/HBoxContainer/Right" instance=ExtResource("4_eb1ui")]
-
-layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MC/HC"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MC/HC/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/margin_left = 10
@@ -120,16 +82,16 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MC/HC/VBoxContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="HomeButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/MarginContainer/VBoxContainer"]
+[node name="HomeButton" type="Button" parent="MC/HC/VBoxContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 0
 theme_override_font_sizes/font_size = 50
 text = "Home"
 
-[node name="InventoryButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/MarginContainer/VBoxContainer"]
+[node name="InventoryButton" type="Button" parent="MC/HC/VBoxContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 0
 theme_override_font_sizes/font_size = 50
@@ -141,6 +103,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="ColorRect" parent="Popups" instance=ExtResource("5_ka4ym")]
+visible = false
 layout_mode = 0
 offset_left = 1225.0
 offset_top = 476.0

--- a/frontend/Savor-22b/scenes/village_view.tscn
+++ b/frontend/Savor-22b/scenes/village_view.tscn
@@ -50,6 +50,24 @@ grow_vertical = 2
 theme_override_font_sizes/font_size = 70
 text = "Home"
 
+[node name="FarmButtonContainer" type="ColorRect" parent="TopMenuMarginContainer/Control"]
+layout_mode = 0
+offset_left = 460.0
+offset_right = 870.0
+offset_bottom = 100.0
+size_flags_horizontal = 4
+color = Color(0, 0, 0, 1)
+
+[node name="FarmButton" type="Button" parent="TopMenuMarginContainer/Control/FarmButtonContainer"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 70
+text = "Farm"
+
 [node name="BottomMenuMarginContainer" type="MarginContainer" parent="."]
 layout_mode = 0
 offset_top = 940.0
@@ -131,5 +149,5 @@ offset_right = 640.0
 offset_bottom = 340.0
 
 [connection signal="button_down" from="TopMenuMarginContainer/Control/HomeButtonContainer/HomeButton" to="." method="_on_home_button_button_down"]
+[connection signal="button_down" from="TopMenuMarginContainer/Control/FarmButtonContainer/FarmButton" to="." method="_on_farm_button_button_down"]
 [connection signal="button_down" from="BottomMenuMarginContainer/Control/EnterButtonContainer/EnterButton" to="." method="_on_enter_button_button_down"]
-

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -1,4 +1,46 @@
 extends Control
 
+const FARM_SLOT_EMPTY = preload("res://ui/farm_slot_empty.tscn")
+const FARM_SLOT_OCCUPIED = preload("res://ui/farm_slot_button.tscn")
+const FARM_SLOT_DONE = preload("res://ui/farm_slot_done.tscn")
+
+@onready var leftfarm = $MC/HC/CR/MC/HC/Left
+@onready var rightfarm = $MC/HC/CR/MC/HC/Right
+
+var farms = []
+
 func _ready():
 	print("farm scene ready")
+	
+	print(SceneContext.user_state["villageState"]["houseFieldStates"])
+	farms = SceneContext.user_state["villageState"]["houseFieldStates"]
+	
+	#create blank slots
+	for i in range(0,5):
+		var farm
+		if (farms[i] == null):
+			farm = FARM_SLOT_EMPTY.instantiate()
+		else:
+			if(farms[i]["isHarvested"]):
+				farm = FARM_SLOT_DONE.instantiate()
+				farm.set_farm_slot(farms[i])
+			else:
+				farm = FARM_SLOT_OCCUPIED.instantiate()
+				farm.set_farm_slot(farms[i])
+		
+		leftfarm.add_child(farm)
+		
+	for i in range(5,10):
+		var farm
+		if (farms[i] == null):
+			farm = FARM_SLOT_EMPTY.instantiate()
+		else:
+			if(farms[i]["isHarvested"]):
+				farm = FARM_SLOT_DONE.instantiate()
+			else:
+				farm = FARM_SLOT_OCCUPIED.instantiate()
+		
+		rightfarm.add_child(farm)	
+	
+	
+	

--- a/frontend/Savor-22b/scripts/scenes/intro.gd
+++ b/frontend/Savor-22b/scripts/scenes/intro.gd
@@ -90,6 +90,19 @@ func _query_user_state():
 				"itemName",
 			]),
 		]),
+		GQLQuery.new("villageState").set_props([
+			GQLQuery.new("houseFieldStates").set_props([
+				"installedSeedGuid",
+				"seedID",
+				"installedBlock",
+				"totalBlock",
+				"lastWeedBlock",
+				"weedRemovalCount",
+				"seedName",
+				"isHarvested",
+				"weedRemovalAble"
+			])
+		])
 	])
 	print(query.serialize())
 	var query_executor = SvrGqlClient.query(

--- a/frontend/Savor-22b/scripts/scenes/select_village.gd
+++ b/frontend/Savor-22b/scripts/scenes/select_village.gd
@@ -38,4 +38,4 @@ func _on_start_button_button_down():
 	SceneContext.selected_village_width = village["width"]
 	SceneContext.selected_village_height = village["height"]
 		
-	get_tree().change_scene_to_file("res://scenes/village_view.tscn")
+	get_tree().change_scene_to_file("res://scenes/select_house.tscn")

--- a/frontend/Savor-22b/scripts/scenes/village_view.gd
+++ b/frontend/Savor-22b/scripts/scenes/village_view.gd
@@ -77,3 +77,7 @@ func _on_home_button_button_down():
 func _on_enter_button_button_down():
 	pass # Replace with function body.
 
+
+
+func _on_farm_button_button_down():
+	get_tree().change_scene_to_file("res://scenes/farm.tscn")

--- a/frontend/Savor-22b/ui/farm_slot_button.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_button.tscn
@@ -1,10 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://c0qm0ud7mwmwb"]
 
-
 [ext_resource type="Script" path="res://ui/farm_slot_button.gd" id="1_vqq1f"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1e62"]
-
 bg_color = Color(0.6, 0.6, 0.6, 0)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ctkwv"]
@@ -20,7 +18,6 @@ offset_right = 500.0
 offset_bottom = 300.0
 size_flags_vertical = 3
 color = Color(0.866667, 0.498039, 0.215686, 1)
-
 script = ExtResource("1_vqq1f")
 
 [node name="V" type="VBoxContainer" parent="."]
@@ -37,9 +34,7 @@ size_flags_vertical = 3
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxFlat_b1e62")
-
 theme_override_styles/pressed = SubResource("StyleBoxFlat_ctkwv")
-
 text = "[벼] 자라는 중
 [N 블록 남음]"
 

--- a/frontend/Savor-22b/ui/farm_slot_done.gd
+++ b/frontend/Savor-22b/ui/farm_slot_done.gd
@@ -6,8 +6,7 @@ signal button_down(child_index: int)
 
 var farm_slot: Dictionary
 
-var format_string = """%s %s
-	(%d %s)"""
+var format_string = "[%s] %s"
 
 func _ready():
 	_update_button()
@@ -16,8 +15,8 @@ func _update_button():
 	if button == null:
 		return
 
-	button.text = format_string % [farm_slot.seedName, "자라는 중", farm_slot.totalBlock, "블록 남음"]
-	
+	button.text = format_string % [farm_slot.seedName, "수확하기"]
+
 
 func set_farm_slot(farm_slot: Dictionary):
 	self.farm_slot = farm_slot

--- a/frontend/Savor-22b/ui/farm_slot_done.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_done.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://bjcg2kocdfuua"]
+[gd_scene load_steps=4 format=3 uid="uid://bjcg2kocdfuua"]
+
+[ext_resource type="Script" path="res://ui/farm_slot_done.gd" id="1_jh5h4"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1e62"]
 bg_color = Color(0, 0.372549, 1, 1)
@@ -15,6 +17,7 @@ border_color = Color(1, 1, 1, 1)
 offset_right = 500.0
 offset_bottom = 300.0
 size_flags_vertical = 3
+script = ExtResource("1_jh5h4")
 
 [node name="V" type="VBoxContainer" parent="."]
 layout_mode = 1


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
현재 밭의 상태를 볼 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 설치 전 / 중 / 후 상태를 구분하여 밭의 상태를 표현

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="1146" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/c68e1c4d-acd8-4a9f-a264-34b074a078d1">

- 현재 사용자의 밭 데이터를 조회합니다.

<img width="481" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/3576e215-3869-43c0-9522-db0e14b1bc13">

- 조회한 데이터를 기준으로 심기 전 / 중 / 후 를 구분하여 오브젝트를 만듭니다.

