### PR TITLE
SVR-285: 종자 설치 기능

### DIFF
--- a/frontend/Savor-22b/gql/query.gd
+++ b/frontend/Savor-22b/gql/query.gd
@@ -23,3 +23,11 @@ var stage_tx_query_format = "mutation {
 		unsignedTransaction:\"%s\",
 		signature:\"%s\")
 }"
+
+var plant_seed_query_format = "query {
+	createAction_PlantingSeed(
+		publicKey: {},
+		fieldIndex: {},
+		itemStateIdToUse: {}
+	)
+}"

--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://c10m1dv6u7ks7"]
+[gd_scene load_steps=3 format=3 uid="uid://c10m1dv6u7ks7"]
 
 [ext_resource type="Script" path="res://scripts/scenes/farm.gd" id="1_q2tum"]
 [ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="2_vkmuk"]
-[ext_resource type="PackedScene" uid="uid://kttsr2bn7o31" path="res://ui/farm_install_popup.tscn" id="5_ka4ym"]
 
 [node name="Farm" type="Control"]
 layout_mode = 3
@@ -105,11 +104,3 @@ text = "Inventory"
 anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
-
-[node name="ColorRect" parent="Popups" instance=ExtResource("5_ka4ym")]
-visible = false
-layout_mode = 0
-offset_left = 1225.0
-offset_top = 476.0
-offset_right = 1625.0
-offset_bottom = 776.0

--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource type="Script" path="res://scripts/scenes/farm.gd" id="1_q2tum"]
 [ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="2_vkmuk"]
-
 [ext_resource type="PackedScene" uid="uid://kttsr2bn7o31" path="res://ui/farm_install_popup.tscn" id="5_ka4ym"]
 
 [node name="Farm" type="Control"]
@@ -85,11 +84,9 @@ theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MC/HC/VBoxContainer/MarginContainer"]
-
 layout_mode = 2
 
 [node name="Asset" parent="MC/HC/VBoxContainer/MarginContainer/VBoxContainer" instance=ExtResource("2_vkmuk")]
-
 layout_mode = 2
 
 [node name="HomeButton" type="Button" parent="MC/HC/VBoxContainer/MarginContainer/VBoxContainer"]

--- a/frontend/Savor-22b/scenes/select_house.tscn
+++ b/frontend/Savor-22b/scenes/select_house.tscn
@@ -176,5 +176,5 @@ offset_bottom = 340.0
 [connection signal="pressed" from="TopMenuMarginContainer/Control/HomeButtonContainer/Button" to="." method="_on_button_pressed"]
 [connection signal="button_down" from="TopMenuMarginContainer/Control/BackButtonContainer2/BackButton" to="." method="_on_back_button_button_down"]
 [connection signal="button_down" from="BottomMenuMarginContainer/Control/BuildButtonContainer/BuildButton" to="." method="_on_build_button_button_down"]
-[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_build_button_button_down"]
 [connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_refresh_button_button_down"]
+[connection signal="button_down" from="BottomMenuMarginContainer/Control/RefreshButtonContainer/RefreshButton" to="." method="_on_build_button_button_down"]

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -48,6 +48,8 @@ var selected_village_capacity := 0
 var selected_village_width := 0
 var selected_village_height := 0
 
+var selected_field_index := 0
+
 #func _ready():
 	#var json = JSON.new()
 	#var error = json.parse(villages_json_string)

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -4,10 +4,13 @@ const FARM_SLOT_EMPTY = preload("res://ui/farm_slot_empty.tscn")
 const FARM_SLOT_OCCUPIED = preload("res://ui/farm_slot_button.tscn")
 const FARM_SLOT_DONE = preload("res://ui/farm_slot_done.tscn")
 
+const Gql_query = preload("res://gql/query.gd")
+
 @onready var leftfarm = $MC/HC/CR/MC/HC/Left
 @onready var rightfarm = $MC/HC/CR/MC/HC/Right
 
 var farms = []
+var itemStateIdToUse
 
 func _ready():
 	print("farm scene ready")
@@ -20,6 +23,8 @@ func _ready():
 		var farm
 		if (farms[i] == null):
 			farm = FARM_SLOT_EMPTY.instantiate()
+			farm.im_left()
+			farm.button_down.connect(farm_selected)
 		else:
 			if(farms[i]["isHarvested"]):
 				farm = FARM_SLOT_DONE.instantiate()
@@ -34,6 +39,8 @@ func _ready():
 		var farm
 		if (farms[i] == null):
 			farm = FARM_SLOT_EMPTY.instantiate()
+			farm.im_right()
+			farm.button_down.connect(farm_selected)
 		else:
 			if(farms[i]["isHarvested"]):
 				farm = FARM_SLOT_DONE.instantiate()
@@ -43,4 +50,8 @@ func _ready():
 		rightfarm.add_child(farm)	
 	
 	
-	
+func farm_selected(farm_index):
+	var format_string = "farm selected: %s"
+	print(format_string % farm_index)
+	SceneContext.selected_field_index = farm_index
+

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -52,8 +52,10 @@ func _ready():
 		else:
 			if(farms[i]["isHarvested"]):
 				farm = FARM_SLOT_DONE.instantiate()
+				farm.set_farm_slot(farms[i])				
 			else:
 				farm = FARM_SLOT_OCCUPIED.instantiate()
+				farm.set_farm_slot(farms[i])				
 		
 		rightfarm.add_child(farm)
 	
@@ -74,13 +76,15 @@ func plant_popup():
 	var installpopup = INSTALL_POPUP.instantiate()
 	popuparea.add_child(installpopup)
 	installpopup.set_position(mousepos)
+	installpopup.accept_button_down.connect(plant_seed)
+	
 
 func plant_seed():
 	var gql_query = Gql_query.new()
 	var query_string = gql_query.plant_seed_query_format.format([
 		"\"%s\"" % GlobalSigner.signer.GetPublicKey(),
 		SceneContext.selected_field_index,
-		itemStateIds["stateID"]], "{}")
+		"\"%s\"" % itemStateIds[0]["stateID"]], "{}")
 	print(query_string)
 	
 	var query_executor = SvrGqlClient.raw(query_string)

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -10,6 +10,7 @@ const Gql_query = preload("res://gql/query.gd")
 @onready var rightfarm = $MC/HC/CR/MC/HC/Right
 
 var farms = []
+var itemStateIds = []
 var itemStateIdToUse
 
 func _ready():
@@ -17,6 +18,9 @@ func _ready():
 	
 	print(SceneContext.user_state["villageState"]["houseFieldStates"])
 	farms = SceneContext.user_state["villageState"]["houseFieldStates"]
+	
+	print(SceneContext.user_state["inventoryState"]["itemStateList"])
+	itemStateIds = SceneContext.user_state["inventoryState"]["itemStateList"]
 	
 	#create blank slots
 	for i in range(0,5):

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -4,10 +4,14 @@ const FARM_SLOT_EMPTY = preload("res://ui/farm_slot_empty.tscn")
 const FARM_SLOT_OCCUPIED = preload("res://ui/farm_slot_button.tscn")
 const FARM_SLOT_DONE = preload("res://ui/farm_slot_done.tscn")
 
+const INSTALL_POPUP = preload("res://ui/farm_install_popup.tscn")
+
 const Gql_query = preload("res://gql/query.gd")
 
 @onready var leftfarm = $MC/HC/CR/MC/HC/Left
 @onready var rightfarm = $MC/HC/CR/MC/HC/Right
+
+@onready var popuparea = $Popups
 
 var farms = []
 var itemStateIds = []
@@ -51,21 +55,32 @@ func _ready():
 			else:
 				farm = FARM_SLOT_OCCUPIED.instantiate()
 		
-		rightfarm.add_child(farm)	
+		rightfarm.add_child(farm)
 	
 	
 func farm_selected(farm_index):
 	var format_string = "farm selected: %s"
 	print(format_string % farm_index)
 	SceneContext.selected_field_index = farm_index
+	
+	plant_popup()
 
+func plant_popup():
+	if is_instance_valid(popuparea):
+		for child in popuparea.get_children():
+			child.queue_free()
+	
+	var mousepos = get_local_mouse_position() + Vector2(0, -200)
+	var installpopup = INSTALL_POPUP.instantiate()
+	popuparea.add_child(installpopup)
+	installpopup.set_position(mousepos)
 
 func plant_seed():
 	var gql_query = Gql_query.new()
 	var query_string = gql_query.plant_seed_query_format.format([
 		"\"%s\"" % GlobalSigner.signer.GetPublicKey(),
 		SceneContext.selected_field_index,
-		itemStateIdToUse], "{}")
+		itemStateIds["stateID"]], "{}")
 	print(query_string)
 	
 	var query_executor = SvrGqlClient.raw(query_string)

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -72,8 +72,11 @@ func plant_popup():
 		for child in popuparea.get_children():
 			child.queue_free()
 	
+	var amount = itemStateIds.size()
+	print(amount)
 	var mousepos = get_local_mouse_position() + Vector2(0, -200)
 	var installpopup = INSTALL_POPUP.instantiate()
+	installpopup.set_amount(amount)
 	popuparea.add_child(installpopup)
 	installpopup.set_position(mousepos)
 	installpopup.accept_button_down.connect(plant_seed)

--- a/frontend/Savor-22b/scripts/scenes/intro.gd
+++ b/frontend/Savor-22b/scripts/scenes/intro.gd
@@ -68,6 +68,11 @@ func _query_user_state():
 				"seedId",
 				"name",
 			]),
+			GQLQuery.new("itemStateList").set_props([
+				"stateID",
+				"itemID",
+				"itemName",
+			]),
 			GQLQuery.new("refrigeratorStateList").set_props([
 				"stateId",
 				"ingredientId",

--- a/frontend/Savor-22b/ui/farm_install_popup.gd
+++ b/frontend/Savor-22b/ui/farm_install_popup.gd
@@ -1,0 +1,14 @@
+extends Panel
+
+
+func _ready():
+	pass # Replace with function body.
+
+
+
+func _on_accept_button_down():
+	pass # Replace with function body.
+
+
+func _on_cancel_button_down():
+	queue_free()

--- a/frontend/Savor-22b/ui/farm_install_popup.gd
+++ b/frontend/Savor-22b/ui/farm_install_popup.gd
@@ -2,10 +2,28 @@ extends Panel
 
 signal accept_button_down
 
+@onready var infotext = $VBoxContainer/MarginContainer/Text
+
+var format_string = """%s 
+	%s (%d %s)"""
+
+var amount: int
+
 func _ready():
-	pass # Replace with function body.
+	_update_text()
 
 
+func _update_text():
+	if infotext == null:
+		return
+
+	infotext.text = format_string % ["랜덤 종자 하나를 소모해서", "종자를 심기", amount, "개 남음"]
+	
+	
+
+func set_amount(amount: int):
+	self.amount = amount
+	_update_text()
 
 func _on_accept_button_down():
 	accept_button_down.emit()

--- a/frontend/Savor-22b/ui/farm_install_popup.gd
+++ b/frontend/Savor-22b/ui/farm_install_popup.gd
@@ -1,5 +1,6 @@
 extends Panel
 
+signal accept_button_down
 
 func _ready():
 	pass # Replace with function body.
@@ -7,7 +8,7 @@ func _ready():
 
 
 func _on_accept_button_down():
-	pass # Replace with function body.
+	accept_button_down.emit()
 
 
 func _on_cancel_button_down():

--- a/frontend/Savor-22b/ui/farm_install_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_install_popup.tscn
@@ -2,12 +2,10 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1w3ox"]
 bg_color = Color(0.866667, 0.498039, 0.215686, 1)
-
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-
 border_color = Color(0, 0, 0, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6tw4s"]
@@ -34,22 +32,18 @@ theme_override_font_sizes/font_size = 50
 text = "   종자 심기"
 vertical_alignment = 1
 
-
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_bottom = 10
 
 [node name="Text" type="Label" parent="VBoxContainer/MarginContainer"]
-
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 35
-
 text = "랜덤 종자 하나를 소모해서
 종자를 심기 (n개 남음)"
-
 vertical_alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]

--- a/frontend/Savor-22b/ui/farm_install_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_install_popup.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://kttsr2bn7o31"]
+[gd_scene load_steps=4 format=3 uid="uid://kttsr2bn7o31"]
+
+[ext_resource type="Script" path="res://ui/farm_install_popup.gd" id="1_nl4pl"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1w3ox"]
 bg_color = Color(0.866667, 0.498039, 0.215686, 1)
@@ -15,6 +17,7 @@ bg_color = Color(0, 0, 0, 1)
 offset_right = 400.0
 offset_bottom = 300.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_1w3ox")
+script = ExtResource("1_nl4pl")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -68,3 +71,6 @@ text = "  취소  "
 
 [node name="Blank" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
+
+[connection signal="button_down" from="VBoxContainer/HBoxContainer/Accept" to="." method="_on_accept_button_down"]
+[connection signal="button_down" from="VBoxContainer/HBoxContainer/Cancel" to="." method="_on_cancel_button_down"]

--- a/frontend/Savor-22b/ui/farm_slot_empty.gd
+++ b/frontend/Savor-22b/ui/farm_slot_empty.gd
@@ -1,9 +1,5 @@
 extends ColorRect
 
-const INSTALL_POPUP = preload("res://ui/farm_install_popup.tscn")
-
-@onready var popup = $Popup
-
 signal button_down(child_index: int)
 
 var isleft: bool
@@ -13,6 +9,7 @@ func _ready():
 
 func _on_button_button_down():
 	
+	# return index of selected slot
 	if (isleft):
 		button_down.emit(get_index())
 	else:

--- a/frontend/Savor-22b/ui/farm_slot_empty.gd
+++ b/frontend/Savor-22b/ui/farm_slot_empty.gd
@@ -1,0 +1,21 @@
+extends ColorRect
+
+signal button_down(child_index: int)
+
+var isleft: bool
+
+func _ready():
+	pass
+
+func _on_button_button_down():
+	
+	if (isleft):
+		button_down.emit(get_index())
+	else:
+		button_down.emit(get_index()+5)
+
+func im_right():
+	isleft = false
+
+func im_left():
+	isleft = true

--- a/frontend/Savor-22b/ui/farm_slot_empty.gd
+++ b/frontend/Savor-22b/ui/farm_slot_empty.gd
@@ -1,5 +1,9 @@
 extends ColorRect
 
+const INSTALL_POPUP = preload("res://ui/farm_install_popup.tscn")
+
+@onready var popup = $Popup
+
 signal button_down(child_index: int)
 
 var isleft: bool
@@ -13,6 +17,8 @@ func _on_button_button_down():
 		button_down.emit(get_index())
 	else:
 		button_down.emit(get_index()+5)
+		
+
 
 func im_right():
 	isleft = false

--- a/frontend/Savor-22b/ui/farm_slot_empty.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_empty.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://bf6be56dhvlws"]
+[gd_scene load_steps=4 format=3 uid="uid://bf6be56dhvlws"]
+
+[ext_resource type="Script" path="res://ui/farm_slot_empty.gd" id="1_qsptk"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1e62"]
 bg_color = Color(0.243137, 1, 0.215686, 1)
@@ -20,6 +22,7 @@ offset_bottom = -780.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_vertical = 3
+script = ExtResource("1_qsptk")
 
 [node name="V" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -38,3 +41,5 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_b1e62")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_esont")
 text = "[비어있음]
 종자 심기"
+
+[connection signal="button_down" from="V/Button" to="." method="_on_button_button_down"]

--- a/frontend/Savor-22b/ui/farm_slot_empty.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_empty.tscn
@@ -42,4 +42,11 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_esont")
 text = "[비어있음]
 종자 심기"
 
+[node name="Popup" type="Control" parent="."]
+anchors_preset = 0
+offset_left = 530.0
+offset_top = -8.0
+offset_right = 570.0
+offset_bottom = 32.0
+
 [connection signal="button_down" from="V/Button" to="." method="_on_button_button_down"]

--- a/frontend/Savor-22b/ui/farm_slot_empty.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_empty.tscn
@@ -42,11 +42,4 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_esont")
 text = "[비어있음]
 종자 심기"
 
-[node name="Popup" type="Control" parent="."]
-anchors_preset = 0
-offset_left = 530.0
-offset_top = -8.0
-offset_right = 570.0
-offset_bottom = 32.0
-
 [connection signal="button_down" from="V/Button" to="." method="_on_button_button_down"]


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
선택한 구역에 종자 설치가 가능합니다.
# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
종자 설치 기능을 추가합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="956" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/69056d11-0a5c-4236-b8da-add3afc73432">


- 밭을 선택하면 해당 위치의 인덱스를 저장합니다.
- 랜덤 종자 아이템이 있는 아이템 목록을 불러옵니다.
- 선택 시 설치 가능 여부 창을 남은 랜덤 종자 개수와 함께 띄웁니다.
- 확인을 누르면 랜덤 종자 stateID와 밭 위치를 넘겨서 종자 설치를 실행합니다.


# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
자라면서 남은 블럭을 표시하고 싶은데, 지금은 totalblock으로만 표시합니다.
아마 subscription이 완성되면 그때 완벽하게 표시할 수 있지 싶습니다.
