### PR TITLE
SVR-181: 밭의 설치된 종자 제거 기능

### DIFF
--- a/frontend/Savor-22b/gql/query.gd
+++ b/frontend/Savor-22b/gql/query.gd
@@ -40,3 +40,10 @@ var harvest_seed_query_format = "query {
 	)
 }"
 
+
+var remove_seed_query_format = "query {
+	createAction_RemovePlantedSeed(
+		publicKey: {},
+		fieldIndex: {}
+	)
+}"

--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -111,6 +111,4 @@ anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
 
-
 [connection signal="button_down" from="MC/HC/VBoxContainer/MarginContainer/VBoxContainer/RefreshButton" to="." method="_on_refresh_button_button_down"]
-

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -5,9 +5,10 @@ const FARM_SLOT_OCCUPIED = preload("res://ui/farm_slot_button.tscn")
 const FARM_SLOT_DONE = preload("res://ui/farm_slot_done.tscn")
 
 const INSTALL_POPUP = preload("res://ui/farm_install_popup.tscn")
-
 const DONE_POPUP = preload("res://ui/done_notice_popup.tscn")
-
+const ACTION_POPUP = preload("res://ui/farm_action_popup.tscn")
+const REMOVE_POPUP = preload("res://ui/farm_ask_remove_popup.tscn")
+const REMOVE_DONE_POPUP = preload("res://ui/farm_remove_done_popup.tscn")
 
 const Gql_query = preload("res://gql/query.gd")
 
@@ -36,6 +37,7 @@ func _ready():
 	itemStateIds = SceneContext.user_state["inventoryState"]["itemStateList"]
 	
 	#create blank slots
+	# Left slot
 	for i in range(0,5):
 		var farm
 		if (farms[i] == null):
@@ -53,11 +55,13 @@ func _ready():
 			else:
 				farm = FARM_SLOT_OCCUPIED.instantiate()
 				farm.im_left()
-				#insert farm.button_down.connect(farm_selected) if needed
+				farm.button_down.connect(farm_selected)
+				farm.button_down_action.connect(control_seed)
 				farm.set_farm_slot(farms[i])
 		
 		leftfarm.add_child(farm)
-		
+	
+	# Right slot
 	for i in range(5,10):
 		var farm
 		if (farms[i] == null):
@@ -75,7 +79,8 @@ func _ready():
 			else:
 				farm = FARM_SLOT_OCCUPIED.instantiate()
 				farm.im_right()
-				#insert farm.button_down.connect(farm_selected) if needed
+				farm.button_down.connect(farm_selected)
+				farm.button_down_action.connect(control_seed)
 				farm.set_farm_slot(farms[i])
 		
 		rightfarm.add_child(farm)
@@ -176,7 +181,42 @@ func harvest_seed():
 	query_executor.run({})
 	actionSuccess = true
 	fetch_new()
+
+func action_popup():
+	print("행동 팝업")
+	if is_instance_valid(popuparea):
+		for child in popuparea.get_children():
+			child.queue_free()
 	
+	var actionpopup = ACTION_POPUP.instantiate()
+	popuparea.add_child(actionpopup)
+	actionpopup.set_position(Vector2(700,500))
+	actionpopup.button_down_remove.connect(remove_popup)
+	
+func remove_popup():
+	if is_instance_valid(popuparea):
+		for child in popuparea.get_children():
+			child.queue_free()
+	
+	var removepopup = REMOVE_POPUP.instantiate()
+	popuparea.add_child(removepopup)
+	removepopup.set_position(Vector2(700,500))
+	removepopup.button_yes.connect(remove_done_popup)
+	
+func remove_done_popup():
+	if is_instance_valid(popuparea):
+		for child in popuparea.get_children():
+			child.queue_free()
+	
+	var donepopup = REMOVE_DONE_POPUP.instantiate()
+	popuparea.add_child(donepopup)
+	donepopup.set_position(Vector2(700,500))
+	donepopup.refresh_me.connect(fetch_new)
+
+func control_seed():
+	#code here
+	action_popup()
+
 func fetch_new():
 # fetch datas
 	Intro._query_user_state()
@@ -195,7 +235,6 @@ func fetch_new():
 			child.queue_free()
 	
 	_ready()
-
 
 func _on_refresh_button_button_down():
 	fetch_new()

--- a/frontend/Savor-22b/ui/farm_action_popup.gd
+++ b/frontend/Savor-22b/ui/farm_action_popup.gd
@@ -1,0 +1,12 @@
+extends ColorRect
+
+signal button_down_remove
+
+
+func _ready():
+	pass # Replace with function body.
+
+
+func _on_remove_button_down():
+	button_down_remove.emit()
+

--- a/frontend/Savor-22b/ui/farm_action_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_action_popup.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://brn1piu848fxo"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yesvl"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="ActionPopup" type="ColorRect"]
+custom_minimum_size = Vector2(400, 100)
+offset_right = 400.0
+offset_bottom = 200.0
+color = Color(0.866667, 0.498039, 0.215686, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="Remove" type="Button" parent="M/V"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_yesvl")
+text = "제거하기"

--- a/frontend/Savor-22b/ui/farm_action_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_action_popup.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://brn1piu848fxo"]
+[gd_scene load_steps=3 format=3 uid="uid://brn1piu848fxo"]
+
+[ext_resource type="Script" path="res://ui/farm_action_popup.gd" id="1_ma8qk"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yesvl"]
 bg_color = Color(0, 0, 0, 1)
@@ -8,6 +10,7 @@ custom_minimum_size = Vector2(400, 100)
 offset_right = 400.0
 offset_bottom = 200.0
 color = Color(0.866667, 0.498039, 0.215686, 1)
+script = ExtResource("1_ma8qk")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -30,3 +33,5 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxFlat_yesvl")
 text = "제거하기"
+
+[connection signal="button_down" from="M/V/Remove" to="." method="_on_remove_button_down"]

--- a/frontend/Savor-22b/ui/farm_ask_remove_popup.gd
+++ b/frontend/Savor-22b/ui/farm_ask_remove_popup.gd
@@ -1,0 +1,17 @@
+extends ColorRect
+
+signal button_yes
+
+
+
+func _ready():
+	pass # Replace with function body.
+
+
+
+func _on_accept_button_down():
+	button_yes.emit()
+
+
+func _on_cancel_button_down():
+	queue_free()

--- a/frontend/Savor-22b/ui/farm_ask_remove_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_ask_remove_popup.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=2 format=3 uid="uid://im1tn3x7uvfu"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5kg0i"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="AskPopup" type="ColorRect"]
+offset_right = 900.0
+offset_bottom = 200.0
+color = Color(1, 1, 0, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_right = 30
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="Text" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "정말로 해당 종자를 제거하시겠습니까?"
+horizontal_alignment = 1
+
+[node name="H" type="HBoxContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/separation = 100
+alignment = 1
+
+[node name="Cancel" type="Button" parent="M/V/H"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_5kg0i")
+text = "      취소      "
+
+[node name="Accept" type="Button" parent="M/V/H"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_5kg0i")
+text = "      확인      "

--- a/frontend/Savor-22b/ui/farm_ask_remove_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_ask_remove_popup.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://im1tn3x7uvfu"]
+[gd_scene load_steps=3 format=3 uid="uid://im1tn3x7uvfu"]
+
+[ext_resource type="Script" path="res://ui/farm_ask_remove_popup.gd" id="1_nakgl"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5kg0i"]
 bg_color = Color(0, 0, 0, 1)
@@ -7,6 +9,7 @@ bg_color = Color(0, 0, 0, 1)
 offset_right = 900.0
 offset_bottom = 200.0
 color = Color(1, 1, 0, 1)
+script = ExtResource("1_nakgl")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -50,3 +53,6 @@ theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxFlat_5kg0i")
 text = "      확인      "
+
+[connection signal="button_down" from="M/V/H/Cancel" to="." method="_on_cancel_button_down"]
+[connection signal="button_down" from="M/V/H/Accept" to="." method="_on_accept_button_down"]

--- a/frontend/Savor-22b/ui/farm_remove_done_popup.gd
+++ b/frontend/Savor-22b/ui/farm_remove_done_popup.gd
@@ -1,0 +1,11 @@
+extends ColorRect
+
+signal refresh_me
+
+func _ready():
+	pass # Replace with function body.
+
+
+func _on_button_button_down():
+	refresh_me.emit()
+	queue_free()

--- a/frontend/Savor-22b/ui/farm_remove_done_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_remove_done_popup.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=2 format=3 uid="uid://c48jlsophfki6"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eamck"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="RemoveDonePopup" type="ColorRect"]
+offset_right = 700.0
+offset_bottom = 160.0
+color = Color(0.866667, 0.498039, 0.215686, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_right = 50
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="Label" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "종자가 제거되었습니다."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="M/V"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_eamck")
+text = "      확인      "

--- a/frontend/Savor-22b/ui/farm_remove_done_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_remove_done_popup.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://c48jlsophfki6"]
+[gd_scene load_steps=3 format=3 uid="uid://c48jlsophfki6"]
+
+[ext_resource type="Script" path="res://ui/farm_remove_done_popup.gd" id="1_6dq0m"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eamck"]
 bg_color = Color(0, 0, 0, 1)
@@ -7,6 +9,7 @@ bg_color = Color(0, 0, 0, 1)
 offset_right = 700.0
 offset_bottom = 160.0
 color = Color(0.866667, 0.498039, 0.215686, 1)
+script = ExtResource("1_6dq0m")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -37,3 +40,5 @@ theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxFlat_eamck")
 text = "      확인      "
+
+[connection signal="button_down" from="M/V/Button" to="." method="_on_button_button_down"]

--- a/frontend/Savor-22b/ui/farm_slot_button.gd
+++ b/frontend/Savor-22b/ui/farm_slot_button.gd
@@ -1,6 +1,7 @@
 extends ColorRect
 
 signal button_down(child_index: int)
+signal button_down_action
 
 @onready var button = $V/Button
 
@@ -30,7 +31,7 @@ func _on_button_button_down():
 		button_down.emit(get_index())
 	else:
 		button_down.emit(get_index()+5)
-
+	button_down_action.emit()
 
 
 func im_right():

--- a/frontend/Savor-22b/ui/farm_slot_button.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_button.tscn
@@ -47,3 +47,5 @@ theme_override_colors/font_color = Color(0, 1, 0, 1)
 theme_override_font_sizes/font_size = 40
 text = "[잡초 제거 필요]"
 horizontal_alignment = 1
+
+[connection signal="button_down" from="V/Button" to="." method="_on_button_button_down"]


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
자라던 중 맘에 안 들면 뽑아버릴 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 만약에 종자를 심었는데 필요 없으면 다른 거 심고 싶을 수 있는 경우에 필요한 제거 액션을 추가합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
<img width="683" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/81ab8b47-a33f-431a-b310-143a315be244">
<img width="684" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/4d273bd5-e79f-4f72-9d95-c4956f960734">
<img width="681" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/0fb56198-ba00-410a-b19a-0ea993b9ac26">
<img width="681" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/e25d7d59-1c13-479a-93b5-f4fa2b6a35cc">


- 종자 액션에 필요한 UI 추가
- 자라는 종자를 선택하면 팝업 메뉴가 나오도록 함
- 팝업 메뉴에서 종자를 제거할 수 있도록 함
- 제거는 신중해야 하기 때문에 한번 더 물어보고 진행


# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
역시 변경된 사항은 10초정도 뒤에 리프레시를 누르시면 잘 보입니다.