### PR TITLE
SVR-169: 시스템 상점 구매 가능 아이템 출력

### DIFF
--- a/frontend/Savor-22b/scenes/shop/ask_popup.gd
+++ b/frontend/Savor-22b/scenes/shop/ask_popup.gd
@@ -1,0 +1,17 @@
+extends ColorRect
+
+signal buy_button_down
+
+func _ready():
+	pass # Replace with function body.
+
+
+
+
+
+func _on_buy_button_down():
+	buy_button_down.emit()
+
+
+func _on_cancel_button_down():
+	queue_free()

--- a/frontend/Savor-22b/scenes/shop/ask_popup.tscn
+++ b/frontend/Savor-22b/scenes/shop/ask_popup.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=3 format=3 uid="uid://taqcgkosj1e6"]
+
+[ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="1_t0req"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yhy67"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="AskPopup" type="ColorRect"]
+offset_right = 600.0
+offset_bottom = 350.0
+color = Color(1, 0.541176, 0, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Itemname" type="Label" parent="M/V"]
+layout_mode = 2
+size_flags_vertical = 1
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "(아이템 이름) 을
+구매하시겠습니까?
+"
+
+[node name="Asset" parent="M/V" instance=ExtResource("1_t0req")]
+layout_mode = 2
+
+[node name="H" type="HBoxContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/separation = 50
+alignment = 2
+
+[node name="Cancel" type="Button" parent="M/V/H"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
+text = "      취소      "
+
+[node name="Buy" type="Button" parent="M/V/H"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
+text = "      구매      "

--- a/frontend/Savor-22b/scenes/shop/ask_popup.tscn
+++ b/frontend/Savor-22b/scenes/shop/ask_popup.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://taqcgkosj1e6"]
+[gd_scene load_steps=4 format=3 uid="uid://taqcgkosj1e6"]
 
 [ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="1_t0req"]
+[ext_resource type="Script" path="res://scenes/shop/ask_popup.gd" id="1_ulgkj"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yhy67"]
 bg_color = Color(0, 0, 0, 1)
@@ -9,6 +10,7 @@ bg_color = Color(0, 0, 0, 1)
 offset_right = 600.0
 offset_bottom = 350.0
 color = Color(1, 0.541176, 0, 1)
+script = ExtResource("1_ulgkj")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -54,3 +56,6 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
 text = "      구매      "
+
+[connection signal="button_down" from="M/V/H/Cancel" to="." method="_on_cancel_button_down"]
+[connection signal="button_down" from="M/V/H/Buy" to="." method="_on_buy_button_down"]

--- a/frontend/Savor-22b/scenes/shop/done_popup.tscn
+++ b/frontend/Savor-22b/scenes/shop/done_popup.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=2 format=3 uid="uid://e4jeslfxnied"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xo5gb"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="DonePopup" type="ColorRect"]
+offset_right = 600.0
+offset_bottom = 200.0
+pivot_offset = Vector2(-716, 741)
+color = Color(1, 0.541176, 0, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 14
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -84.0
+offset_bottom = 84.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+
+[node name="Info" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "구매가 완료되었습니다."
+horizontal_alignment = 1
+
+[node name="Cancel" type="Button" parent="M/V"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_xo5gb")
+text = "      확인      "

--- a/frontend/Savor-22b/scenes/shop/shop_item.gd
+++ b/frontend/Savor-22b/scenes/shop/shop_item.gd
@@ -1,0 +1,29 @@
+extends ColorRect
+
+signal button_down(item_id: int)
+
+@onready var itemname = $M/V/Itemname
+@onready var desc = $M/V/Description/Text
+
+var item: Dictionary
+
+var desc_format_string = "%s"
+
+func _ready():
+	update_item()
+
+
+func update_item():
+	if itemname == null:
+		return
+	
+		# 아이템 설명이 추가되면 아이디 대신 이름 넣고 설명 란에 설명 추가하면 됩니다.
+	itemname.text = str(item.id)
+	desc.text = item.name
+
+func set_item(info: Dictionary):
+	item = info
+
+
+func _on_buy_button_down():
+	button_down.emit(item.id)

--- a/frontend/Savor-22b/scenes/shop/shop_item.tscn
+++ b/frontend/Savor-22b/scenes/shop/shop_item.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=2 format=3 uid="uid://bhh3viy4esoci"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yhy67"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="ShopItem" type="ColorRect"]
+offset_right = 600.0
+offset_bottom = 300.0
+color = Color(1, 0.541176, 0, 1)
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Itemname" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "아이템 이름"
+
+[node name="Description" type="ColorRect" parent="M/V"]
+layout_mode = 2
+size_flags_vertical = 3
+color = Color(0.619608, 0.34902, 0, 1)
+
+[node name="Text" type="Label" parent="M/V/Description"]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 23.0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 40
+text = "아이템 설명"
+
+[node name="H" type="HBoxContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/separation = 50
+alignment = 2
+
+[node name="Cancel" type="Button" parent="M/V/H"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
+text = "      취소      "
+
+[node name="Buy" type="Button" parent="M/V/H"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
+text = "      구매      "

--- a/frontend/Savor-22b/scenes/shop/shop_item.tscn
+++ b/frontend/Savor-22b/scenes/shop/shop_item.tscn
@@ -1,12 +1,17 @@
-[gd_scene load_steps=2 format=3 uid="uid://bhh3viy4esoci"]
+[gd_scene load_steps=3 format=3 uid="uid://bhh3viy4esoci"]
+
+[ext_resource type="Script" path="res://scenes/shop/shop_item.gd" id="1_beefs"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yhy67"]
 bg_color = Color(0, 0, 0, 1)
 
 [node name="ShopItem" type="ColorRect"]
+custom_minimum_size = Vector2(600, 300)
 offset_right = 600.0
 offset_bottom = 300.0
+size_flags_horizontal = 3
 color = Color(1, 0.541176, 0, 1)
+script = ExtResource("1_beefs")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -48,14 +53,10 @@ layout_mode = 2
 theme_override_constants/separation = 50
 alignment = 2
 
-[node name="Cancel" type="Button" parent="M/V/H"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
-text = "      취소      "
-
 [node name="Buy" type="Button" parent="M/V/H"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_yhy67")
 text = "      구매      "
+
+[connection signal="button_down" from="M/V/H/Buy" to="." method="_on_buy_button_down"]

--- a/frontend/Savor-22b/scenes/shop/systemshop.gd
+++ b/frontend/Savor-22b/scenes/shop/systemshop.gd
@@ -1,0 +1,8 @@
+extends ColorRect
+
+
+
+func _ready():
+	pass # Replace with function body.
+
+

--- a/frontend/Savor-22b/scenes/shop/systemshop.gd
+++ b/frontend/Savor-22b/scenes/shop/systemshop.gd
@@ -1,8 +1,34 @@
-extends ColorRect
+extends Panel
 
+const ITEM = preload("res://scenes/shop/shop_item.tscn")
+const SHOP_ASK_POPUP = preload("res://scenes/shop/ask_popup.tscn")
+const SHOP_DONE_POPUP = preload("res://scenes/shop/done_popup.tscn")
 
+@onready var shoplist = $M/H/C/M/Lists
+@onready var popup = $Popups
+
+var shopitems = []
 
 func _ready():
-	pass # Replace with function body.
+	print("shop opened")
+	shopitems = SceneContext.shop
+	print(shopitems)
+	var size = shopitems.size()
+	
+	for item in shopitems["items"]:
+		print(item)
+		var singleitem = ITEM.instantiate()
+		singleitem.set_item(item)
+		singleitem.button_down.connect(buy_item)
+		shoplist.add_child(singleitem)
 
 
+func buy_item():
+	print("buy item")
+	var askpopup = SHOP_ASK_POPUP.instantiate()
+	
+	popup.add_child(askpopup)
+	
+
+func _on_close_button_down():
+	queue_free()

--- a/frontend/Savor-22b/scenes/shop/systemshop.tscn
+++ b/frontend/Savor-22b/scenes/shop/systemshop.tscn
@@ -1,14 +1,23 @@
-[gd_scene load_steps=4 format=3 uid="uid://bqf2y10ecg1vu"]
+[gd_scene load_steps=5 format=3 uid="uid://bqf2y10ecg1vu"]
 
 [ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="1_mqe47"]
 [ext_resource type="Script" path="res://scenes/shop/systemshop.gd" id="1_oxfr7"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kwjar"]
+bg_color = Color(1, 1, 1, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pm0cc"]
 bg_color = Color(0, 0, 0, 1)
 
-[node name="Shop" type="ColorRect"]
+[node name="Shop" type="Panel"]
 offset_right = 720.0
 offset_bottom = 900.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_kwjar")
 script = ExtResource("1_oxfr7")
 
 [node name="M" type="MarginContainer" parent="."]
@@ -59,3 +68,17 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="Lists" type="VBoxContainer" parent="M/H/C/M"]
+layout_mode = 2
+
+[node name="Popups" type="Control" parent="."]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[connection signal="button_down" from="M/H/HBoxContainer/Close" to="." method="_on_close_button_down"]

--- a/frontend/Savor-22b/scenes/shop/systemshop.tscn
+++ b/frontend/Savor-22b/scenes/shop/systemshop.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://bqf2y10ecg1vu"]
+[gd_scene load_steps=4 format=3 uid="uid://bqf2y10ecg1vu"]
 
 [ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="1_mqe47"]
+[ext_resource type="Script" path="res://scenes/shop/systemshop.gd" id="1_oxfr7"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pm0cc"]
 bg_color = Color(0, 0, 0, 1)
@@ -8,6 +9,7 @@ bg_color = Color(0, 0, 0, 1)
 [node name="Shop" type="ColorRect"]
 offset_right = 720.0
 offset_bottom = 900.0
+script = ExtResource("1_oxfr7")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1

--- a/frontend/Savor-22b/scenes/shop/systemshop.tscn
+++ b/frontend/Savor-22b/scenes/shop/systemshop.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=3 format=3 uid="uid://bqf2y10ecg1vu"]
+
+[ext_resource type="PackedScene" uid="uid://co4t4p5pawylr" path="res://ui/asset.tscn" id="1_mqe47"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pm0cc"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="Shop" type="ColorRect"]
+offset_right = 720.0
+offset_bottom = 900.0
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 20
+
+[node name="H" type="VBoxContainer" parent="M"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="M/H"]
+layout_mode = 2
+theme_override_constants/separation = 480
+
+[node name="Title" type="Label" parent="M/H/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 70
+text = "상점"
+
+[node name="Close" type="Button" parent="M/H/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_pm0cc")
+text = "  X  "
+
+[node name="Asset" parent="M/H" instance=ExtResource("1_mqe47")]
+layout_mode = 2
+
+[node name="C" type="ColorRect" parent="M/H"]
+layout_mode = 2
+size_flags_vertical = 3
+color = Color(0, 0, 0, 1)
+
+[node name="M" type="MarginContainer" parent="M/H/C"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/frontend/Savor-22b/scenes/testpanel/test_panel.gd
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.gd
@@ -1,8 +1,9 @@
 extends Control
 
+@onready var label = $Background/MarginContainer/GridContainer/Label
 
 func _ready():
-	pass # Replace with function body.
+	pass
 
 func _input(event):
 	if event is InputEventKey and event.pressed:
@@ -13,3 +14,9 @@ func _input(event):
 
 func _on_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/farm.tscn")
+
+
+func _on_button_2_pressed():
+	
+	var test = SceneContext.shop
+	print(test)

--- a/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
@@ -44,4 +44,16 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 50
 text = "farm.tscn"
 
+[node name="button2" type="Button" parent="Background/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "text set"
+
+[node name="Label" type="Label" parent="Background/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+text = "label text"
+
 [connection signal="pressed" from="Background/MarginContainer/GridContainer/button" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="Background/MarginContainer/GridContainer/button2" to="." method="_on_button_2_pressed"]

--- a/frontend/Savor-22b/scenes/village_view.tscn
+++ b/frontend/Savor-22b/scenes/village_view.tscn
@@ -148,6 +148,11 @@ offset_top = 300.0
 offset_right = 640.0
 offset_bottom = 340.0
 
+[node name="Popups" type="Control" parent="."]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
 [connection signal="button_down" from="TopMenuMarginContainer/Control/HomeButtonContainer/HomeButton" to="." method="_on_home_button_button_down"]
 [connection signal="button_down" from="TopMenuMarginContainer/Control/FarmButtonContainer/FarmButton" to="." method="_on_farm_button_button_down"]
 [connection signal="button_down" from="BottomMenuMarginContainer/Control/EnterButtonContainer/EnterButton" to="." method="_on_enter_button_button_down"]

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -42,6 +42,8 @@ var selected_village_index := 0
 var user_state: Dictionary
 var user_asset: String
 
+var shop: Dictionary
+
 var selected_house_index := 0
 var selected_house_location: Dictionary
 var selected_village_capacity := 0
@@ -70,4 +72,5 @@ func set_user_asset(query_data: Dictionary):
 func get_selected_village():
 	return villages[selected_village_index]
 
-
+func set_shop(query_data: Dictionary):
+	shop = query_data.data.shop

--- a/frontend/Savor-22b/scripts/scenes/intro.gd
+++ b/frontend/Savor-22b/scripts/scenes/intro.gd
@@ -5,6 +5,8 @@ func _ready():
 	_query_villages()
 	_query_user_state()
 	_query_assets()
+	_query_shop()
+
 
 func _on_quit_button_button_down():
 	print("quit button down")
@@ -145,6 +147,26 @@ func _query_user_state():
 	query_executor.run({
 		"signer_address": GlobalSigner.signer_address
 	})
+	
+func _query_shop():
+	var query = GQLQuery.new("shop").set_props([
+		GQLQuery.new("items").set_props([
+			"id",
+			"name",
+			"price",
+		])
+	])
+	print(query.serialize())
+	var query_executor = SvrGqlClient.query(
+		'query',{}, query)
+		
+	query_executor.graphql_response.connect(
+		func(data):
+			SceneContext.set_shop(data)
+	)
+	add_child(query_executor)
+	query_executor.run({})
+
 
 func reload_datas():
 	_query_villages()

--- a/frontend/Savor-22b/scripts/scenes/village_view.gd
+++ b/frontend/Savor-22b/scripts/scenes/village_view.gd
@@ -2,7 +2,12 @@ extends Control
 
 const SELECT_HOUSE_BUTTON = preload("res://ui/house_slot_button.tscn")
 
+const SYS_SHOP = preload("res://scenes/shop/systemshop.tscn")
+
+
 @onready var gridcontainer = $MarginContainer/Background/MarginContainer/ScrollContainer/HomeGridContainer
+
+@onready var popups = $Popups
 
 var houses = []
 var existhouses = SceneContext.get_selected_village()["houses"]
@@ -81,3 +86,12 @@ func _on_enter_button_button_down():
 
 func _on_farm_button_button_down():
 	get_tree().change_scene_to_file("res://scenes/farm.tscn")
+
+#open shop with S input
+func _input(event):
+	if event is InputEventKey and event.pressed:
+		if event.keycode == KEY_S:
+			var shop = SYS_SHOP.instantiate()
+			popups.add_child(shop)
+			shop.set_position(Vector2(400, 150))
+


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
S를 눌러 시스템 상점을 열 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 마을 중앙에 물리적인 형태로 존재하지 않고, 언제든 접근 가능한 인터페이스 형식

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->

<img width="954" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/8ed6ffb5-8819-4c72-a2df-bd245d8db90b">

- 상점에 필요한 UI
- 상점 데이터 가져오기
- 상점 UI 기능 연결
- 데이터를 UI로 표시
