### PR TITLE
SVR-162: 집 화면의 인벤토리에서 조리기구 목록 조회

### DIFF
--- a/frontend/Savor-22b/scenes/farm.tscn
+++ b/frontend/Savor-22b/scenes/farm.tscn
@@ -111,4 +111,5 @@ anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
 
+[connection signal="button_down" from="MC/HC/VBoxContainer/MarginContainer/VBoxContainer/HomeButton" to="." method="_on_home_button_button_down"]
 [connection signal="button_down" from="MC/HC/VBoxContainer/MarginContainer/VBoxContainer/RefreshButton" to="." method="_on_refresh_button_button_down"]

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -1,0 +1,75 @@
+[gd_scene load_steps=2 format=3 uid="uid://bpobpaan3tquv"]
+
+[ext_resource type="Script" path="res://scripts/scenes/house.gd" id="1_suicg"]
+
+[node name="House" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_suicg")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="Background"]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 23.0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 60
+text = " 집 화면"
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+
+[node name="menus" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="V" type="VBoxContainer" parent="M/V/menus"]
+layout_mode = 2
+size_flags_horizontal = 8
+
+[node name="HomeButton" type="Button" parent="M/V/menus/V"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "Home"
+
+[node name="InventoryButton" type="Button" parent="M/V/menus/V"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "Inventory"
+
+[node name="RefreshButton" type="Button" parent="M/V/menus/V"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "Refresh"
+
+[node name="subscene" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -73,3 +73,5 @@ size_flags_vertical = 3
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
+
+[connection signal="button_down" from="M/V/menus/V/InventoryButton" to="." method="_on_inventory_button_button_down"]

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -49,11 +49,11 @@ theme_override_constants/margin_bottom = 20
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="HomeButton" type="Button" parent="M/V/menus/V"]
+[node name="RecipeButton" type="Button" parent="M/V/menus/V"]
 layout_mode = 2
 size_flags_vertical = 0
 theme_override_font_sizes/font_size = 50
-text = "Home"
+text = "Recipe"
 
 [node name="InventoryButton" type="Button" parent="M/V/menus/V"]
 layout_mode = 2

--- a/frontend/Savor-22b/scenes/house/house_inventory.gd
+++ b/frontend/Savor-22b/scenes/house/house_inventory.gd
@@ -1,6 +1,7 @@
 extends Control
 
 const KITCHEN_TOOLS = preload("res://scenes/house/kitchentools.tscn")
+const KITCHEN_SHOP = preload("res://scenes/house/kitchenshop.tscn")
 
 @onready var panel = $M/V/Panel/C
 
@@ -9,3 +10,22 @@ func _ready():
 	
 	panel.add_child(kitchens)
 
+
+
+
+func _on_tools_button_down():
+	clear_popup()
+	var kitchens = KITCHEN_TOOLS.instantiate()
+	
+	panel.add_child(kitchens)
+
+func _on_shop_button_down():
+	clear_popup()
+	var kitchens = KITCHEN_SHOP.instantiate()
+	
+	panel.add_child(kitchens)
+	
+func clear_popup():
+	if is_instance_valid(panel):
+		for pop in panel.get_children():
+			pop.queue_free()

--- a/frontend/Savor-22b/scenes/house/house_inventory.gd
+++ b/frontend/Savor-22b/scenes/house/house_inventory.gd
@@ -1,0 +1,11 @@
+extends Control
+
+const KITCHEN_TOOLS = preload("res://scenes/house/kitchentools.tscn")
+
+@onready var panel = $M/V/Panel/C
+
+func _ready():
+	var kitchens = KITCHEN_TOOLS.instantiate()
+	
+	panel.add_child(kitchens)
+

--- a/frontend/Savor-22b/scenes/house/house_inventory.tscn
+++ b/frontend/Savor-22b/scenes/house/house_inventory.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://dupiw5pjpvulw"]
+[gd_scene load_steps=4 format=3 uid="uid://dupiw5pjpvulw"]
+
+[ext_resource type="Script" path="res://scenes/house/house_inventory.gd" id="1_7w8e6"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dth2p"]
 bg_color = Color(0, 0, 0, 1)
@@ -13,6 +15,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_7w8e6")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -42,7 +45,7 @@ layout_mode = 2
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_50occ")
 
-[node name="M" type="MarginContainer" parent="M/V/Panel"]
+[node name="C" type="CenterContainer" parent="M/V/Panel"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/frontend/Savor-22b/scenes/house/house_inventory.tscn
+++ b/frontend/Savor-22b/scenes/house/house_inventory.tscn
@@ -34,11 +34,21 @@ layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 
-[node name="tools" type="Button" parent="M/V/submenu"]
+[node name="H" type="HBoxContainer" parent="M/V/submenu"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="tools" type="Button" parent="M/V/submenu/H"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_dth2p")
 text = " 조리 도구 "
+
+[node name="shop" type="Button" parent="M/V/submenu/H"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_dth2p")
+text = " 도구 상점 "
 
 [node name="Panel" type="Panel" parent="M/V"]
 layout_mode = 2
@@ -52,3 +62,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[connection signal="button_down" from="M/V/submenu/H/tools" to="." method="_on_tools_button_down"]
+[connection signal="button_down" from="M/V/submenu/H/shop" to="." method="_on_shop_button_down"]

--- a/frontend/Savor-22b/scenes/house/house_inventory.tscn
+++ b/frontend/Savor-22b/scenes/house/house_inventory.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=3 format=3 uid="uid://dupiw5pjpvulw"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dth2p"]
+bg_color = Color(0, 0, 0, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_50occ"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="HouseInventory" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = -1
+
+[node name="submenu" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+
+[node name="tools" type="Button" parent="M/V/submenu"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_dth2p")
+text = " 조리 도구 "
+
+[node name="Panel" type="Panel" parent="M/V"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_styles/panel = SubResource("StyleBoxFlat_50occ")
+
+[node name="M" type="MarginContainer" parent="M/V/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/frontend/Savor-22b/scenes/house/kitchenshop.gd
+++ b/frontend/Savor-22b/scenes/house/kitchenshop.gd
@@ -1,0 +1,17 @@
+extends Control
+
+const TOOL = preload("res://scenes/house/tool.tscn")
+
+@onready var grid = $M/V/Items/G
+
+var list
+
+func _ready():
+	list = SceneContext.shop["kitchenEquipments"]
+	
+	for tool in list:
+		var toolpanel = TOOL.instantiate()
+		toolpanel.set_slottype()
+		toolpanel.set_info(tool)
+		grid.add_child(toolpanel)
+

--- a/frontend/Savor-22b/scenes/house/kitchenshop.tscn
+++ b/frontend/Savor-22b/scenes/house/kitchenshop.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=3 format=3 uid="uid://bsj3rpdgusned"]
+
+[ext_resource type="Script" path="res://scenes/house/kitchenshop.gd" id="1_aqlr8"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rk6tx"]
+bg_color = Color(1, 0.541176, 0, 1)
+
+[node name="Kitchenshop" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -357.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_aqlr8")
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 8
+
+[node name="Items" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 50
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
+
+[node name="G" type="GridContainer" parent="M/V/Items"]
+custom_minimum_size = Vector2(1780, 500)
+layout_mode = 2
+theme_override_constants/h_separation = 50
+theme_override_constants/v_separation = 50
+columns = 5
+
+[node name="Button" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/margin_right = 80
+
+[node name="Close" type="Button" parent="M/V/Button"]
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_rk6tx")
+text = "   닫기   "

--- a/frontend/Savor-22b/scenes/house/kitchentools.gd
+++ b/frontend/Savor-22b/scenes/house/kitchentools.gd
@@ -1,0 +1,16 @@
+extends Control
+
+const TOOL = preload("res://scenes/house/tool.tscn")
+
+@onready var grid = $M/V/Items/G
+
+var tools
+
+func _ready():
+	tools = SceneContext.user_state.inventoryState["kitchenEquipmentStateList"]
+	
+	for tool in tools:
+		var toolpanel = TOOL.instantiate()
+		toolpanel.set_info(tool)
+		grid.add_child(toolpanel)
+

--- a/frontend/Savor-22b/scenes/house/kitchentools.tscn
+++ b/frontend/Savor-22b/scenes/house/kitchentools.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://cwqquis7w31g7"]
+[gd_scene load_steps=3 format=3 uid="uid://cwqquis7w31g7"]
+
+[ext_resource type="Script" path="res://scenes/house/kitchentools.gd" id="1_bkji1"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rk6tx"]
 bg_color = Color(1, 0.541176, 0, 1)
@@ -8,8 +10,10 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = -357.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_bkji1")
 
 [node name="M" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -21,12 +25,22 @@ grow_vertical = 2
 
 [node name="V" type="VBoxContainer" parent="M"]
 layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 8
 
 [node name="Items" type="MarginContainer" parent="M/V"]
 layout_mode = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 50
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 50
 
 [node name="G" type="GridContainer" parent="M/V/Items"]
+custom_minimum_size = Vector2(1780, 500)
 layout_mode = 2
+theme_override_constants/h_separation = 50
+theme_override_constants/v_separation = 50
+columns = 5
 
 [node name="Button" type="MarginContainer" parent="M/V"]
 layout_mode = 2

--- a/frontend/Savor-22b/scenes/house/kitchentools.tscn
+++ b/frontend/Savor-22b/scenes/house/kitchentools.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=2 format=3 uid="uid://cwqquis7w31g7"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rk6tx"]
+bg_color = Color(1, 0.541176, 0, 1)
+
+[node name="Kitchentools" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+
+[node name="Items" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+
+[node name="G" type="GridContainer" parent="M/V/Items"]
+layout_mode = 2
+
+[node name="Button" type="MarginContainer" parent="M/V"]
+layout_mode = 2
+theme_override_constants/margin_right = 80
+
+[node name="Close" type="Button" parent="M/V/Button"]
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_rk6tx")
+text = "   닫기   "

--- a/frontend/Savor-22b/scenes/house/tool.gd
+++ b/frontend/Savor-22b/scenes/house/tool.gd
@@ -4,6 +4,10 @@ extends Panel
 @onready var tooldesc = $M/V/Desc
 
 var info
+var isshop: bool = false
+
+var desc_format_string = "%s : %s
+%s : %s %s"
 
 func _ready():
 	_update_info()
@@ -13,9 +17,17 @@ func _update_info():
 	if toolname == null:
 		return
 	
-	toolname.text = info.equipmentName
-	tooldesc.text = info.stateId
+	if (isshop):
+		toolname.text = info.name
+		tooldesc.text = desc_format_string % [info.categoryType, info.categoryLabel, "Price", info.price, "BBG"]
+	else:
+		toolname.text = info.equipmentName
+		tooldesc.text = info.stateId
 
 func set_info(info: Dictionary):
 	self.info = info
+	
+func set_slottype():
+	self.isshop = true
+	_update_info()
 	

--- a/frontend/Savor-22b/scenes/house/tool.gd
+++ b/frontend/Savor-22b/scenes/house/tool.gd
@@ -1,0 +1,21 @@
+extends Panel
+
+@onready var toolname = $M/V/Name
+@onready var tooldesc = $M/V/Desc
+
+var info
+
+func _ready():
+	_update_info()
+
+
+func _update_info():
+	if toolname == null:
+		return
+	
+	toolname.text = info.equipmentName
+	tooldesc.text = info.stateId
+
+func set_info(info: Dictionary):
+	self.info = info
+	

--- a/frontend/Savor-22b/scenes/house/tool.tscn
+++ b/frontend/Savor-22b/scenes/house/tool.tscn
@@ -1,18 +1,27 @@
-[gd_scene load_steps=2 format=3 uid="uid://cjlj4mej5h001"]
+[gd_scene load_steps=3 format=3 uid="uid://cjlj4mej5h001"]
+
+[ext_resource type="Script" path="res://scenes/house/tool.gd" id="1_fsq81"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x6mfd"]
 bg_color = Color(1, 0.541176, 0, 1)
 
 [node name="Tool" type="Panel"]
 custom_minimum_size = Vector2(300, 200)
-offset_right = 40.0
-offset_bottom = 40.0
+offset_right = 300.0
+offset_bottom = 200.0
+size_flags_horizontal = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_x6mfd")
+script = ExtResource("1_fsq81")
 
 [node name="M" type="MarginContainer" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -18.5
+offset_bottom = 18.5
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
@@ -29,7 +38,10 @@ theme_override_font_sizes/font_size = 40
 text = "조리도구 이름"
 
 [node name="Desc" type="Label" parent="M/V"]
+custom_minimum_size = Vector2(260, 132)
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 30
 text = "조리도구 설명"
+autowrap_mode = 1
+max_lines_visible = 3

--- a/frontend/Savor-22b/scenes/house/tool.tscn
+++ b/frontend/Savor-22b/scenes/house/tool.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=2 format=3 uid="uid://cjlj4mej5h001"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x6mfd"]
+bg_color = Color(1, 0.541176, 0, 1)
+
+[node name="Tool" type="Panel"]
+custom_minimum_size = Vector2(300, 200)
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_x6mfd")
+
+[node name="M" type="MarginContainer" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="V" type="VBoxContainer" parent="M"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Name" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 40
+text = "조리도구 이름"
+
+[node name="Desc" type="Label" parent="M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 30
+text = "조리도구 설명"

--- a/frontend/Savor-22b/scenes/shop/shop_item.gd
+++ b/frontend/Savor-22b/scenes/shop/shop_item.gd
@@ -7,7 +7,7 @@ signal button_down
 
 var item: Dictionary
 
-var desc_format_string = "%s"
+var desc_format_string = "%s : %s %s"
 
 func _ready():
 	update_item()
@@ -17,9 +17,8 @@ func update_item():
 	if itemname == null:
 		return
 	
-		# 아이템 설명이 추가되면 아이디 대신 이름 넣고 설명 란에 설명 추가하면 됩니다.
-	itemname.text = str(item.id)
-	desc.text = item.name
+	itemname.text = item.name
+	desc.text = desc_format_string % ["가격", item.price, "BBG"]
 
 func set_item(info: Dictionary):
 	item = info

--- a/frontend/Savor-22b/scripts/scenes/farm.gd
+++ b/frontend/Savor-22b/scripts/scenes/farm.gd
@@ -265,3 +265,7 @@ func fetch_new():
 func _on_refresh_button_button_down():
 	fetch_new()
 
+
+
+func _on_home_button_button_down():
+	get_tree().change_scene_to_file("res://scenes/house/house.tscn")

--- a/frontend/Savor-22b/scripts/scenes/house.gd
+++ b/frontend/Savor-22b/scripts/scenes/house.gd
@@ -1,0 +1,6 @@
+extends Control
+
+
+func _ready():
+	pass # Replace with function body.
+

--- a/frontend/Savor-22b/scripts/scenes/house.gd
+++ b/frontend/Savor-22b/scripts/scenes/house.gd
@@ -1,6 +1,16 @@
 extends Control
 
+const HOUSE_INVENTORY = preload("res://scenes/house/house_inventory.tscn")
+
+@onready var subscene = $M/V/subscene
 
 func _ready():
 	pass # Replace with function body.
 
+
+
+
+func _on_inventory_button_button_down():
+	var inventory = HOUSE_INVENTORY.instantiate()
+	
+	subscene.add_child(inventory)

--- a/frontend/Savor-22b/scripts/scenes/intro.gd
+++ b/frontend/Savor-22b/scripts/scenes/intro.gd
@@ -154,6 +154,15 @@ func _query_shop():
 			"id",
 			"name",
 			"price",
+		]),
+		GQLQuery.new("kitchenEquipments").set_props([
+			"id",
+			"categoryID",
+			"categoryLabel",
+			"categoryType",
+			"name",
+			"blockTimeReductionPercent",
+			"price"
 		])
 	])
 	print(query.serialize())


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
집 화면에서 접근할 수 있는 집 상점의 조리도구 리스트를 볼 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 농장의 home으로 집으로 들어갈 수 있습니다.
- 집에서 인벤토리를 들어가면 내부에 상점 버튼을 눌러 탭을 전환할 수 있습니다.
- 상점 탭에서는 파는 조리도구를 볼 수 있습니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->

<img width="950" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/8a0fa0de-c171-43ae-90fd-9562e669ddf3">

- 상점에서 조리도구 리스트를 받아올 수 있도록 기능 수정
- 상점과 아이템 표현에 필요한 UI 요소 추가


# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
처음에 조금 잘못 이해해서 가지고 있는 조리 도구를 볼 수 있는 기능이 별도로 있습니다.
