### PR TITLE
SVR-163: 집 화면의 인벤토리 내 상점에서 구매 기능

### DIFF
--- a/frontend/Savor-22b/gql/query.gd
+++ b/frontend/Savor-22b/gql/query.gd
@@ -55,3 +55,10 @@ var buy_shop_item_query_format = "query {
 		desiredShopItemID: {}
 	)
 }"
+
+var buy_kitchen_equipment_query_format = "query {
+	createAction_BuyKitchenEquipment(
+		publicKey: {},
+		desiredEquipmentID: {}
+	)
+}"

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -74,4 +74,9 @@ theme_override_constants/margin_left = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
+[node name="Popups" type="Control" parent="."]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
 [connection signal="button_down" from="M/V/menus/V/InventoryButton" to="." method="_on_inventory_button_button_down"]

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -80,3 +80,4 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [connection signal="button_down" from="M/V/menus/V/InventoryButton" to="." method="_on_inventory_button_button_down"]
+[connection signal="button_down" from="M/V/menus/V/RefreshButton" to="." method="_on_refresh_button_button_down"]

--- a/frontend/Savor-22b/scenes/house/house_inventory.gd
+++ b/frontend/Savor-22b/scenes/house/house_inventory.gd
@@ -18,13 +18,13 @@ func _ready():
 func _on_tools_button_down():
 	clear_popup()
 	var kitchens = KITCHEN_TOOLS.instantiate()
-	
+	kitchens.closetab.connect(closetab)
 	panel.add_child(kitchens)
 
 func _on_shop_button_down():
 	clear_popup()
 	var kitchens = KITCHEN_SHOP.instantiate()
-	
+	kitchens.closetab.connect(closetab)
 	kitchens.buysignal.connect(popup)
 	panel.add_child(kitchens)
 	
@@ -32,6 +32,9 @@ func clear_popup():
 	if is_instance_valid(panel):
 		for pop in panel.get_children():
 			pop.queue_free()
+
+func closetab():
+	queue_free()
 
 func popup():
 	buysignal.emit()

--- a/frontend/Savor-22b/scenes/house/house_inventory.gd
+++ b/frontend/Savor-22b/scenes/house/house_inventory.gd
@@ -5,6 +5,8 @@ const KITCHEN_SHOP = preload("res://scenes/house/kitchenshop.tscn")
 
 @onready var panel = $M/V/Panel/C
 
+signal buysignal
+
 func _ready():
 	var kitchens = KITCHEN_TOOLS.instantiate()
 	
@@ -23,9 +25,13 @@ func _on_shop_button_down():
 	clear_popup()
 	var kitchens = KITCHEN_SHOP.instantiate()
 	
+	kitchens.buysignal.connect(popup)
 	panel.add_child(kitchens)
 	
 func clear_popup():
 	if is_instance_valid(panel):
 		for pop in panel.get_children():
 			pop.queue_free()
+
+func popup():
+	buysignal.emit()

--- a/frontend/Savor-22b/scenes/house/kitchenshop.gd
+++ b/frontend/Savor-22b/scenes/house/kitchenshop.gd
@@ -5,6 +5,7 @@ const TOOL = preload("res://scenes/house/tool.tscn")
 @onready var grid = $M/V/Items/G
 
 signal buysignal
+signal closetab
 
 var list
 
@@ -20,3 +21,8 @@ func _ready():
 
 func popup():
 	buysignal.emit()
+
+
+func _on_close_button_down():
+	closetab.emit()
+	queue_free()

--- a/frontend/Savor-22b/scenes/house/kitchenshop.gd
+++ b/frontend/Savor-22b/scenes/house/kitchenshop.gd
@@ -4,6 +4,8 @@ const TOOL = preload("res://scenes/house/tool.tscn")
 
 @onready var grid = $M/V/Items/G
 
+signal buysignal
+
 var list
 
 func _ready():
@@ -13,5 +15,8 @@ func _ready():
 		var toolpanel = TOOL.instantiate()
 		toolpanel.set_slottype()
 		toolpanel.set_info(tool)
+		toolpanel.buysignal.connect(popup)
 		grid.add_child(toolpanel)
 
+func popup():
+	buysignal.emit()

--- a/frontend/Savor-22b/scenes/house/kitchenshop.tscn
+++ b/frontend/Savor-22b/scenes/house/kitchenshop.tscn
@@ -53,3 +53,5 @@ theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_rk6tx")
 text = "   닫기   "
+
+[connection signal="button_down" from="M/V/Button/Close" to="." method="_on_close_button_down"]

--- a/frontend/Savor-22b/scenes/house/kitchentools.gd
+++ b/frontend/Savor-22b/scenes/house/kitchentools.gd
@@ -4,6 +4,8 @@ const TOOL = preload("res://scenes/house/tool.tscn")
 
 @onready var grid = $M/V/Items/G
 
+signal closetab
+
 var tools
 
 func _ready():
@@ -13,4 +15,10 @@ func _ready():
 		var toolpanel = TOOL.instantiate()
 		toolpanel.set_info(tool)
 		grid.add_child(toolpanel)
+
+
+
+func _on_close_button_down():
+	closetab.emit()
+	queue_free()
 

--- a/frontend/Savor-22b/scenes/house/kitchentools.tscn
+++ b/frontend/Savor-22b/scenes/house/kitchentools.tscn
@@ -53,3 +53,5 @@ theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_rk6tx")
 text = "   닫기   "
+
+[connection signal="button_down" from="M/V/Button/Close" to="." method="_on_close_button_down"]

--- a/frontend/Savor-22b/scenes/house/tool.gd
+++ b/frontend/Savor-22b/scenes/house/tool.gd
@@ -2,6 +2,9 @@ extends Panel
 
 @onready var toolname = $M/V/Name
 @onready var tooldesc = $M/V/Desc
+@onready var buybutton = $M/V/Buy
+
+signal buysignal
 
 var info
 var isshop: bool = false
@@ -20,6 +23,7 @@ func _update_info():
 	if (isshop):
 		toolname.text = info.name
 		tooldesc.text = desc_format_string % [info.categoryType, info.categoryLabel, "Price", info.price, "BBG"]
+		buybutton.visible = true
 	else:
 		toolname.text = info.equipmentName
 		tooldesc.text = info.stateId
@@ -31,3 +35,9 @@ func set_slottype():
 	self.isshop = true
 	_update_info()
 	
+
+
+func _on_buy_button_down():
+	SceneContext.selected_item_index = info.id
+	SceneContext.selected_item_name = info.name
+	buysignal.emit()

--- a/frontend/Savor-22b/scenes/house/tool.tscn
+++ b/frontend/Savor-22b/scenes/house/tool.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://cjlj4mej5h001"]
+[gd_scene load_steps=4 format=3 uid="uid://cjlj4mej5h001"]
 
 [ext_resource type="Script" path="res://scenes/house/tool.gd" id="1_fsq81"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x6mfd"]
 bg_color = Color(1, 0.541176, 0, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_v31jt"]
+bg_color = Color(0, 0, 0, 1)
 
 [node name="Tool" type="Panel"]
 custom_minimum_size = Vector2(300, 200)
@@ -38,10 +41,20 @@ theme_override_font_sizes/font_size = 40
 text = "조리도구 이름"
 
 [node name="Desc" type="Label" parent="M/V"]
-custom_minimum_size = Vector2(260, 132)
+custom_minimum_size = Vector2(260, 82)
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 30
 text = "조리도구 설명"
 autowrap_mode = 1
 max_lines_visible = 3
+
+[node name="Buy" type="Button" parent="M/V"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_v31jt")
+text = "      구매      "
+
+[connection signal="button_down" from="M/V/Buy" to="." method="_on_buy_button_down"]

--- a/frontend/Savor-22b/scripts/scenes/house.gd
+++ b/frontend/Savor-22b/scripts/scenes/house.gd
@@ -1,8 +1,12 @@
 extends Control
 
 const HOUSE_INVENTORY = preload("res://scenes/house/house_inventory.tscn")
+const ASK_POPUP = preload("res://scenes/shop/ask_popup.tscn")
+const DONE_POPUP = preload("res://scenes/shop/done_popup.tscn")
+const Gql_query = preload("res://gql/query.gd")
 
 @onready var subscene = $M/V/subscene
+@onready var popup = $Popups
 
 func _ready():
 	pass # Replace with function body.
@@ -12,5 +16,49 @@ func _ready():
 
 func _on_inventory_button_button_down():
 	var inventory = HOUSE_INVENTORY.instantiate()
-	
+	inventory.buysignal.connect(buypopup)
 	subscene.add_child(inventory)
+
+
+func buypopup():
+	var askpopup = ASK_POPUP.instantiate()
+	askpopup.set_itemname(SceneContext.selected_item_name)
+	askpopup.buy_button_down.connect(buyaction)
+	popup.add_child(askpopup)
+
+func buyaction():
+	clear_popup()
+	buytool()
+	
+	var donepopup = DONE_POPUP.instantiate()
+	popup.add_child(donepopup)
+	
+func buytool():
+	var itemnum = SceneContext.selected_item_index
+	var gql_query = Gql_query.new()
+	var query_string = gql_query.buy_kitchen_equipment_query_format.format([
+		"\"%s\"" % GlobalSigner.signer.GetPublicKey(),
+		itemnum], "{}")
+	print(query_string)
+	
+	var query_executor = SvrGqlClient.raw(query_string)
+	query_executor.graphql_response.connect(func(data):
+		print("gql response: ", data)
+		var unsigned_tx = data["data"]["createAction_BuyKitchenEquipment"]
+		print("unsigned tx: ", unsigned_tx)
+		var signature = GlobalSigner.sign(unsigned_tx)
+		print("signed tx: ", signature)
+		var mutation_executor = SvrGqlClient.raw_mutation(gql_query.stage_tx_query_format % [unsigned_tx, signature])
+		mutation_executor.graphql_response.connect(func(data):
+			print("mutation res: ", data)
+		)
+		add_child(mutation_executor)
+		mutation_executor.run({})
+	)
+	add_child(query_executor)
+	query_executor.run({})
+	
+func clear_popup():
+	if is_instance_valid(popup):
+		for pop in popup.get_children():
+			pop.queue_free()

--- a/frontend/Savor-22b/scripts/scenes/house.gd
+++ b/frontend/Savor-22b/scripts/scenes/house.gd
@@ -24,6 +24,7 @@ func buypopup():
 	var askpopup = ASK_POPUP.instantiate()
 	askpopup.set_itemname(SceneContext.selected_item_name)
 	askpopup.buy_button_down.connect(buyaction)
+	askpopup.set_position(Vector2(900,600))
 	popup.add_child(askpopup)
 
 func buyaction():
@@ -31,6 +32,7 @@ func buyaction():
 	buytool()
 	
 	var donepopup = DONE_POPUP.instantiate()
+	donepopup.set_position(Vector2(900,600))
 	popup.add_child(donepopup)
 	
 func buytool():
@@ -62,3 +64,12 @@ func clear_popup():
 	if is_instance_valid(popup):
 		for pop in popup.get_children():
 			pop.queue_free()
+
+
+
+func _on_refresh_button_button_down():
+	Intro._query_user_state()
+	
+	if is_instance_valid(subscene):
+		for scene in subscene.get_children():
+			scene.queue_free()


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
조리도구를 살 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 조리도구 목록을 보는 게 끝이 아니고 살 수 있어야겠죠?

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->

<img width="686" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/514a67ec-1d9a-4ff6-8bcd-8753850ea442">

<img width="699" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/329f3dcd-86db-4c39-884d-af7c929eb0bb">




- 상점 메뉴에서 구매 버튼이 보입니다.
- 누르면 확인 후 구매가 됩니다.
- 구매한 아이템은 Refresh한 후에 다시 열어보시면 나옵니다.


