### PR TITLE
[SVR-165] [부엌] 부엌 화면 & 식재료와 조리도구 조회

### DIFF
--- a/frontend/Savor-22b/gql/svr_gql_client.gd
+++ b/frontend/Savor-22b/gql/svr_gql_client.gd
@@ -2,9 +2,9 @@ extends GQLClient
 
 func _ready():
 	print("client ready")
-	set_endpoint(false, "1.230.253.103", 38080, "/graphql")
+	#set_endpoint(false, "1.230.253.103", 38080, "/graphql")
 	
-	#set_endpoint(false, "localhost", 38080, "/graphql")
+	set_endpoint(false, "localhost", 38080, "/graphql")
 	
 
 func raw_mutation(query:String):

--- a/frontend/Savor-22b/gql/svr_gql_client_2.gd
+++ b/frontend/Savor-22b/gql/svr_gql_client_2.gd
@@ -1,0 +1,11 @@
+extends GQLClient2
+
+func _ready():
+	print("client 2 ready")
+	#set_endpoint(false, "1.230.253.103", 38080, "/graphql")
+	
+	set_endpoint_2(false, "localhost", 38080, "/graphql/explorer")
+	
+
+func raw_mutation(query:String):
+	return GQLQueryExecuter2.new(endpoint, use_ssl, Mutation.new(query))

--- a/frontend/Savor-22b/project.godot
+++ b/frontend/Savor-22b/project.godot
@@ -20,6 +20,7 @@ config/icon="res://icon.svg"
 
 GlobalSigner="*res://scripts/sign/Signer.gd"
 SvrGqlClient="*res://gql/svr_gql_client.gd"
+SvrGqlClient2="*res://gql/svr_gql_client_2.gd"
 SceneContext="*res://scripts/global/scene_context.gd"
 GlobalInventory="*res://scripts/global/inventory.gd"
 Intro="*res://scripts/scenes/intro.gd"

--- a/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.gd
+++ b/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.gd
@@ -1,0 +1,67 @@
+extends Control
+
+const SLOT_EMPTY = preload("res://scenes/house/Kitchen/tool_slot_empty.tscn")
+const SLOT_NOT_USED = preload("res://scenes/house/Kitchen/tool_not_used.tscn")
+const SLOT_USED = preload("res://scenes/house/Kitchen/tool_is_used.tscn")
+
+@onready var slot = $P/M/V/Slot
+
+var largeslots: Dictionary
+var largetools: Array
+
+func _ready():
+
+	load_data()
+	
+#slot 1
+	var slot1 = largeslots["firstApplianceSpace"]
+	if (slot1.installedKitchenEquipment == null): # not installed
+		var bigslot = SLOT_EMPTY.instantiate()
+		slot.add_child(bigslot)
+	else: # installed but not used
+		if (!slot1["installedKitchenEquipment"]["isCooking"]):
+			var bigslot = SLOT_NOT_USED.instantiate()
+			bigslot.set_data(slot1)
+			slot.add_child(bigslot)
+		else: # cooking
+			var bigslot = SLOT_USED.instantiate()
+			bigslot.set_data(slot1)
+			slot.add_child(bigslot)
+#slot 2
+	var slot2 = largeslots["secondApplianceSpace"]
+	if (slot2.installedKitchenEquipment == null):
+		var bigslot = SLOT_EMPTY.instantiate()
+		slot.add_child(bigslot)
+	else:
+		if (!slot2["installedKitchenEquipment"]["isCooking"]):
+			var bigslot = SLOT_NOT_USED.instantiate()
+			bigslot.set_data(slot2)
+			slot.add_child(bigslot)
+		else:
+			var bigslot = SLOT_USED.instantiate()
+			bigslot.set_data(slot2)
+			slot.add_child(bigslot)
+#slot 3
+	var slot3 = largeslots["thirdApplianceSpace"]
+	if (slot3.installedKitchenEquipment == null):
+		var bigslot = SLOT_EMPTY.instantiate()
+		slot.add_child(bigslot)
+	else:
+		if (!slot3["installedKitchenEquipment"]["isCooking"]):
+			var bigslot = SLOT_NOT_USED.instantiate()
+			bigslot.set_data(slot3)
+			slot.add_child(bigslot)
+		else:
+			var bigslot = SLOT_USED.instantiate()
+			bigslot.set_data(slot3)
+			slot.add_child(bigslot)
+
+	
+func load_data():
+	largeslots = SceneContext.user_kitchen_state["villageState"]["houseState"]["kitchenState"]
+	
+	var tools = SceneContext.user_state["inventoryState"]["kitchenEquipmentStateList"]
+	for tool in tools:
+		if(tool.equipmentCategoryType == "main"):
+			largetools.append(tool)
+

--- a/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=2 format=3 uid="uid://bo1s5xygod4cl"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mt11v"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="BigToolSlot" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="P" type="Panel" parent="."]
+layout_mode = 0
+offset_right = 1400.0
+offset_bottom = 600.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_mt11v")
+
+[node name="M" type="MarginContainer" parent="P"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 15
+
+[node name="V" type="VBoxContainer" parent="P/M"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="P/M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+text = "큰 조리도구 사용 슬롯"
+
+[node name="Slot" type="HBoxContainer" parent="P/M/V"]
+layout_mode = 2

--- a/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/big_tool_slot.tscn
@@ -1,20 +1,27 @@
-[gd_scene load_steps=2 format=3 uid="uid://bo1s5xygod4cl"]
+[gd_scene load_steps=3 format=3 uid="uid://bo1s5xygod4cl"]
+
+[ext_resource type="Script" path="res://scenes/house/Kitchen/big_tool_slot.gd" id="1_4yu3x"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mt11v"]
 bg_color = Color(0, 0, 0, 1)
 
 [node name="BigToolSlot" type="Control"]
+custom_minimum_size = Vector2(1400, 550)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = -520.0
+offset_bottom = -530.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 4
+script = ExtResource("1_4yu3x")
 
 [node name="P" type="Panel" parent="."]
 layout_mode = 0
 offset_right = 1400.0
-offset_bottom = 600.0
+offset_bottom = 550.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_mt11v")
 
 [node name="M" type="MarginContainer" parent="P"]
@@ -40,3 +47,4 @@ text = "큰 조리도구 사용 슬롯"
 
 [node name="Slot" type="HBoxContainer" parent="P/M/V"]
 layout_mode = 2
+theme_override_constants/separation = 20

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.gd
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.gd
@@ -1,0 +1,31 @@
+extends Control
+
+@onready var Desc = $P/Desc
+
+var data
+var requiredtime
+var foodname
+
+var format_string = "[%s] 요리 조리중
+[%s 블록 남음]"
+
+func _ready():
+	update_label()
+
+
+
+func update_label():
+	if Desc == null:
+		return
+	
+	Desc.text = format_string % [foodname, requiredtime]
+
+func set_data(info: Dictionary):
+	data = info
+	
+	# set end times
+	var endtime = data["cookingEndBlockIndex"]
+	var currenttime = SceneContext.block_index["blockQuery"]["blocks"][0]["index"]
+	requiredtime = endtime - currenttime
+	
+	foodname = data["cookingFood"]["name"]

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://cs43iommrj00v"]
+[gd_scene load_steps=3 format=3 uid="uid://cs43iommrj00v"]
+
+[ext_resource type="Script" path="res://scenes/house/Kitchen/cook_menu.gd" id="1_tn6pc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6jp5j"]
 bg_color = Color(0.94902, 0.596078, 0.0784314, 1)
@@ -8,12 +10,16 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
 [node name="CookMenu" type="Control"]
+custom_minimum_size = Vector2(400, 250)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = -1520.0
+offset_bottom = -830.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_tn6pc")
 
 [node name="P" type="Panel" parent="."]
 layout_mode = 0

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_menu.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=3 uid="uid://cs43iommrj00v"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6jp5j"]
+bg_color = Color(0.94902, 0.596078, 0.0784314, 1)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[node name="CookMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="P" type="Panel" parent="."]
+layout_mode = 0
+offset_right = 400.0
+offset_bottom = 250.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_6jp5j")
+
+[node name="Desc" type="Label" parent="P"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 40
+text = "[-- -] 요리 조리중
+[N 블록 남음]"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.gd
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.gd
@@ -1,0 +1,55 @@
+extends Control
+
+const MENU = preload("res://scenes/house/Kitchen/cook_menu.tscn")
+
+@onready var slot = $P/M/V/S/Slot
+
+var menus: Array
+var largeslots: Dictionary
+var largearr: Array		#큰 조리도구의 메뉴
+
+func _ready():
+	load_data();
+	
+	for menu in menus:
+		var singlemenu = MENU.instantiate()
+		singlemenu.set_data(menu)
+		slot.add_child(singlemenu)
+	
+	
+func load_data():
+	var refrigerator = SceneContext.user_state["inventoryState"]["kitchenEquipmentStateList"]
+	for items in refrigerator:
+		if(items.isCooking):
+			menus.append(items)
+	
+	refine_data()
+
+
+	
+# 큰 조리도구의 메뉴를 제외시킨다
+func refine_data():
+	largeslots = SceneContext.user_kitchen_state["villageState"]["houseState"]["kitchenState"]
+	#print(largeslots)
+	
+	var slot1 = largeslots["firstApplianceSpace"]
+	var slot2 = largeslots["secondApplianceSpace"]
+	var slot3 = largeslots["thirdApplianceSpace"]
+	
+	if (slot1["installedKitchenEquipment"]!= null):
+		var obj1 = slot1["installedKitchenEquipment"]["stateId"]
+		largearr.append(obj1)
+	if (slot2["installedKitchenEquipment"] != null):
+		var obj2 = slot2["installedKitchenEquipment"]["stateId"]
+		largearr.append(obj2)
+	if (slot3["installedKitchenEquipment"] != null):
+		var obj3 = slot3["installedKitchenEquipment"]["stateId"]
+		largearr.append(obj3)
+			
+	print(largearr)
+	
+	for menu in menus:
+		for data in largearr:
+			if data == menu["stateId"]:
+				menus.erase(menu)
+	

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.tscn
@@ -1,15 +1,20 @@
-[gd_scene load_steps=2 format=3 uid="uid://dea1yl6pikg0n"]
+[gd_scene load_steps=3 format=3 uid="uid://dea1yl6pikg0n"]
+
+[ext_resource type="Script" path="res://scenes/house/Kitchen/cook_slot.gd" id="1_kouyr"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q2usp"]
 bg_color = Color(0, 0, 0, 1)
 
 [node name="CookSlot" type="Control"]
+custom_minimum_size = Vector2(1920, 400)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = -680.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_kouyr")
 
 [node name="P" type="Panel" parent="."]
 layout_mode = 0
@@ -44,3 +49,4 @@ vertical_scroll_mode = 0
 
 [node name="Slot" type="HBoxContainer" parent="P/M/V/S"]
 layout_mode = 2
+theme_override_constants/separation = 50

--- a/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/cook_slot.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3 uid="uid://dea1yl6pikg0n"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q2usp"]
+bg_color = Color(0, 0, 0, 1)
+
+[node name="CookSlot" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="P" type="Panel" parent="."]
+layout_mode = 0
+offset_right = 1920.0
+offset_bottom = 400.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_q2usp")
+
+[node name="M" type="MarginContainer" parent="P"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 15
+
+[node name="V" type="VBoxContainer" parent="P/M"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="P/M/V"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 50
+text = "일반 음식 조리 슬롯"
+
+[node name="S" type="ScrollContainer" parent="P/M/V"]
+layout_mode = 2
+vertical_scroll_mode = 0
+
+[node name="Slot" type="HBoxContainer" parent="P/M/V/S"]
+layout_mode = 2

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.gd
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.gd
@@ -1,0 +1,41 @@
+extends Control
+
+@onready var button = $Button
+
+var data: Dictionary
+var requiredtime
+var menuname
+
+var format_string = "현재 [%s] 조리 중
+
+남은 조리 블록 %s 블록"
+
+func _ready():
+	update_text()
+
+
+func update_text():
+	if button == null:
+		return
+	
+	print(SceneContext.block_index)
+	var endtime = data["installedKitchenEquipment"]["cookingEndBlockIndex"]
+	var currenttime = SceneContext.block_index["blockQuery"]["blocks"][0]["index"]
+	var timeleft = endtime - currenttime
+	button.text = format_string % [menuname, timeleft]
+
+
+func set_data(info: Dictionary):
+	data = info
+	menuname = data["installedKitchenEquipment"]["cookingFood"]["name"]
+	time_info()
+	
+func time_info():
+	var recipe = SceneContext.recipe["recipe"]
+	
+	for singlerecipe in recipe:
+		var rcpname = singlerecipe["resultFood"]["name"]
+		if(rcpname == menuname):
+			requiredtime = singlerecipe["requiredBlockCount"]
+	
+	print(requiredtime)

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.tscn
@@ -1,31 +1,39 @@
-[gd_scene load_steps=2 format=3 uid="uid://b7f85oe54slb5"]
+[gd_scene load_steps=3 format=3 uid="uid://b7f85oe54slb5"]
+
+[ext_resource type="Script" path="res://scenes/house/Kitchen/tool_is_used.gd" id="1_fyt0q"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jwjl7"]
-bg_color = Color(0.32549, 1, 0.290196, 1)
+bg_color = Color(0.94902, 0.694118, 0.0784314, 1)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
 [node name="ToolIsUsed" type="Control"]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -1500.0
-offset_bottom = -580.0
+offset_right = -1485.0
+offset_bottom = -630.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_fyt0q")
 
 [node name="Button" type="Button" parent="."]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_left = -7.5
+offset_right = 7.5
+offset_bottom = -30.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 50
+theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_jwjl7")
 text = "현재 [-- -] 조리 중
 

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_is_used.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://b7f85oe54slb5"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jwjl7"]
+bg_color = Color(0.32549, 1, 0.290196, 1)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[node name="ToolIsUsed" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -1500.0
+offset_bottom = -580.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Button" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_jwjl7")
+text = "현재 [-- -] 조리 중
+
+남은 조리 블록 N 블록"

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.gd
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.gd
@@ -1,0 +1,26 @@
+extends Control
+
+@onready var button = $Button
+
+var data: Dictionary
+
+var format_string = "[%s] 도구 설치됨
+
+식재료 사용 시
+요리 조리 가능"
+
+func _ready():
+	update_text()
+
+
+func update_text():
+	if button == null:
+		return
+
+	button.text = format_string % [data["installedKitchenEquipment"]["equipmentName"]]
+
+
+func set_data(info: Dictionary):
+	data = info
+	
+

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3 uid="uid://bg4tb16c7n00g"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pjjvv"]
+bg_color = Color(0.32549, 1, 0.290196, 1)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[node name="ToolNotUsed" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -1500.0
+offset_bottom = -580.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Button" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_pjjvv")
+text = "[-- -] 도구 설치됨
+
+식재료 사용 시
+요리 조리 가능"

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_not_used.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://bg4tb16c7n00g"]
+[gd_scene load_steps=3 format=3 uid="uid://bg4tb16c7n00g"]
+
+[ext_resource type="Script" path="res://scenes/house/Kitchen/tool_not_used.gd" id="1_s4ktm"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pjjvv"]
 bg_color = Color(0.32549, 1, 0.290196, 1)
@@ -8,24 +10,28 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
 [node name="ToolNotUsed" type="Control"]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -1500.0
-offset_bottom = -580.0
+offset_right = -1485.0
+offset_bottom = -630.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_s4ktm")
 
 [node name="Button" type="Button" parent="."]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = -20.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 50
+theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_pjjvv")
 text = "[-- -] 도구 설치됨
 

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_slot_empty.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_slot_empty.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://jm7hptg5twbn"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q6vgf"]
+bg_color = Color(0.32549, 1, 0.290196, 1)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[node name="ToolSlotEmpty" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -1500.0
+offset_bottom = -580.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Button" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_q6vgf")
+text = "비어있음
+
+조리도구 설치 가능"

--- a/frontend/Savor-22b/scenes/house/Kitchen/tool_slot_empty.tscn
+++ b/frontend/Savor-22b/scenes/house/Kitchen/tool_slot_empty.tscn
@@ -8,24 +8,27 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
 [node name="ToolSlotEmpty" type="Control"]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -1500.0
-offset_bottom = -580.0
+offset_right = -1485.0
+offset_bottom = -630.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="Button" type="Button" parent="."]
+custom_minimum_size = Vector2(435, 450)
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = -20.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 50
+theme_override_font_sizes/font_size = 40
 theme_override_styles/normal = SubResource("StyleBoxFlat_q6vgf")
 text = "비어있음
 

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -1,6 +1,13 @@
-[gd_scene load_steps=2 format=3 uid="uid://bpobpaan3tquv"]
+[gd_scene load_steps=3 format=3 uid="uid://bpobpaan3tquv"]
 
 [ext_resource type="Script" path="res://scripts/scenes/house.gd" id="1_suicg"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_n3yrr"]
+bg_color = Color(0.32549, 1, 0.290196, 1)
+corner_radius_top_left = 25
+corner_radius_top_right = 25
+corner_radius_bottom_right = 25
+corner_radius_bottom_left = 25
 
 [node name="House" type="Control"]
 layout_mode = 3
@@ -85,6 +92,19 @@ layout_mode = 2
 size_flags_vertical = 0
 theme_override_font_sizes/font_size = 50
 text = "  새로고침  "
+
+[node name="M" type="MarginContainer" parent="M/V/menus"]
+layout_mode = 2
+theme_override_constants/margin_left = 250
+
+[node name="CookButton" type="Button" parent="M/V/menus/M"]
+custom_minimum_size = Vector2(380, 2.08165e-12)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 45
+theme_override_styles/normal = SubResource("StyleBoxFlat_n3yrr")
+text = "+ 음식 조리하기"
 
 [node name="subscene" type="MarginContainer" parent="M/V"]
 layout_mode = 2

--- a/frontend/Savor-22b/scenes/house/house.tscn
+++ b/frontend/Savor-22b/scenes/house/house.tscn
@@ -95,6 +95,7 @@ text = "  새로고침  "
 
 [node name="M" type="MarginContainer" parent="M/V/menus"]
 layout_mode = 2
+size_flags_horizontal = 0
 theme_override_constants/margin_left = 250
 
 [node name="CookButton" type="Button" parent="M/V/menus/M"]
@@ -112,6 +113,9 @@ size_flags_vertical = 3
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="M/V/subscene"]
+layout_mode = 2
 
 [node name="Popups" type="Control" parent="."]
 anchors_preset = 0

--- a/frontend/Savor-22b/scenes/house/recipebook/recipebook.gd
+++ b/frontend/Savor-22b/scenes/house/recipebook/recipebook.gd
@@ -1,5 +1,7 @@
 extends Control
 
+signal closeall
+
 const RECIPE = preload("res://scenes/house/recipebook/recipe.tscn")
 
 @onready var grid = $background/M/V/S/G
@@ -17,3 +19,4 @@ func _ready():
 
 func _on_close_button_down():
 	queue_free()
+	closeall.emit()

--- a/frontend/Savor-22b/scenes/testpanel/test_panel.gd
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.gd
@@ -1,7 +1,9 @@
 extends Control
 
-@onready var label = $Background/MarginContainer/GridContainer/Label
+const Gql_query = preload("res://gql/query.gd")
 
+@onready var label = $Background/MarginContainer/GridContainer/Label
+@onready var lineedit = $Background/MarginContainer/GridContainer/LineEdit
 func _ready():
 	pass
 
@@ -20,3 +22,44 @@ func _on_button_2_pressed():
 	
 	var test = SceneContext.shop
 	print(test)
+
+
+func _on_button_3_pressed():
+	test4()
+
+# use \" on every double quotation
+
+func test4():
+	var string = lineedit.text
+	print(string)
+	var gql_query = Gql_query.new()
+	var query_string = "query
+{
+  createAction_CreateFood(publicKey:\"044B83CB8CE52392AD9E46FAF398F96C5CD7CDB95A9EA990A9A55CC575237D2B342D3C43AB5E6E149B87F82544769D70E93A10B0B38D9B579E0A895BF58CB7780F\",
+  recipeID: 2,
+  refrigeratorStateIdsToUse: [\"7435f34b-39f6-4829-a6df-4e6f9affab06\",\"aa2c9ec2-2788-4afa-8ee1-d43ec50127a3\",\"bda2e49a-ec87-4e42-bbab-e73488e8d750\"],
+  kitchenEquipmentStateIdsToUse: \"27d27975-b141-4963-b72a-d4cb0e71bc63\")
+}"
+
+	print(query_string)
+	
+	var query_executor = SvrGqlClient.raw(query_string)
+	query_executor.graphql_response.connect(func(data):
+		print("gql response: ", data)
+		var unsigned_tx = data["data"]["createAction_CreateFood"]
+		print("unsigned tx: ", unsigned_tx)
+		var signature = GlobalSigner.sign(unsigned_tx)
+		print("signed tx: ", signature)
+		var mutation_executor = SvrGqlClient.raw_mutation(gql_query.stage_tx_query_format % [unsigned_tx, signature])
+		mutation_executor.graphql_response.connect(func(data):
+			print("mutation res: ", data)
+		)
+		add_child(mutation_executor)
+		mutation_executor.run({})
+	)
+	add_child(query_executor)
+	query_executor.run({})
+
+
+func _on_button_4_pressed():
+	test4()

--- a/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
+++ b/frontend/Savor-22b/scenes/testpanel/test_panel.tscn
@@ -37,7 +37,7 @@ theme_override_constants/margin_bottom = 50
 layout_mode = 2
 theme_override_constants/h_separation = 300
 theme_override_constants/v_separation = 300
-columns = 5
+columns = 3
 
 [node name="button" type="Button" parent="Background/MarginContainer/GridContainer"]
 layout_mode = 2
@@ -55,5 +55,21 @@ theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 50
 text = "label text"
 
+[node name="LineEdit" type="LineEdit" parent="Background/MarginContainer/GridContainer"]
+custom_minimum_size = Vector2(300, 500)
+layout_mode = 2
+
+[node name="button3" type="Button" parent="Background/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "sign"
+
+[node name="button4" type="Button" parent="Background/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "sign"
+
 [connection signal="pressed" from="Background/MarginContainer/GridContainer/button" to="." method="_on_button_pressed"]
 [connection signal="pressed" from="Background/MarginContainer/GridContainer/button2" to="." method="_on_button_2_pressed"]
+[connection signal="pressed" from="Background/MarginContainer/GridContainer/button3" to="." method="_on_button_3_pressed"]
+[connection signal="pressed" from="Background/MarginContainer/GridContainer/button4" to="." method="_on_button_4_pressed"]

--- a/frontend/Savor-22b/scripts/global/scene_context.gd
+++ b/frontend/Savor-22b/scripts/global/scene_context.gd
@@ -41,6 +41,7 @@ var villages: Array
 var selected_village_index := 0
 var user_state: Dictionary
 var user_asset: String
+var user_kitchen_state: Dictionary
 
 var shop: Dictionary
 var recipe: Dictionary
@@ -52,9 +53,11 @@ var selected_village_width := 0
 var selected_village_height := 0
 
 var selected_field_index := 0
-
 var selected_item_index := 0
 var selected_item_name : String
+
+
+var block_index : Dictionary
 
 #func _ready():
 	#var json = JSON.new()
@@ -70,6 +73,9 @@ func set_villages(query_data: Dictionary):
 func set_user_state(query_data: Dictionary):
 	user_state = query_data.data.userState
 
+func set_user_kitchen_state(query_data: Dictionary):
+	user_kitchen_state = query_data.data.userState
+
 func set_user_asset(query_data: Dictionary):
 	user_asset = query_data.data.asset
 
@@ -81,3 +87,6 @@ func set_shop(query_data: Dictionary):
 	
 func set_recipe(query_data: Dictionary):
 	recipe = query_data.data
+	
+func get_current_block(query_data: Dictionary):
+	block_index = query_data.data

--- a/frontend/Savor-22b/scripts/scenes/house.gd
+++ b/frontend/Savor-22b/scripts/scenes/house.gd
@@ -6,13 +6,16 @@ const DONE_POPUP = preload("res://scenes/shop/done_popup.tscn")
 
 const RECIPE = preload("res://scenes/house/recipebook/recipebook.tscn")
 
+const SMALL_COOK = preload("res://scenes/house/Kitchen/cook_slot.tscn")
+const LARGE_COOK = preload("res://scenes/house/Kitchen/big_tool_slot.tscn")
+
 const Gql_query = preload("res://gql/query.gd")
 
 @onready var subscene = $M/V/subscene
 @onready var popup = $Popups
 
 func _ready():
-	pass # Replace with function body.
+	load_kitchen()
 
 
 
@@ -72,6 +75,7 @@ func clear_popup():
 	if is_instance_valid(popup):
 		for pop in popup.get_children():
 			pop.queue_free()
+	load_kitchen()		
 
 func _on_recipe_button_button_down():
 	clear_popup()
@@ -87,11 +91,9 @@ func _on_recipe_button_button_down():
 	subscene.add_child(Recipebookarea)
 
 	var recipebook = RECIPE.instantiate()
+	recipebook.closeall.connect(clear_popup)
 
 	Recipebookarea.add_child(recipebook)
-
-
-
 
 func _on_farm_button_button_down():
 	get_tree().change_scene_to_file("res://scenes/farm.tscn")
@@ -106,3 +108,20 @@ func _on_refresh_button_button_down():
 	if is_instance_valid(subscene):
 		for scene in subscene.get_children():
 			scene.queue_free()
+
+
+func load_kitchen():
+	if is_instance_valid(subscene):
+		for scene in subscene.get_children():
+			scene.queue_free()	
+
+	var Kitchenarea = VBoxContainer.new()
+	Kitchenarea.add_theme_constant_override("separation", 20)
+	subscene.add_child(Kitchenarea)
+	
+	var smallslot = SMALL_COOK.instantiate()
+	Kitchenarea.add_child(smallslot)
+	
+	var largeslot = LARGE_COOK.instantiate()
+	Kitchenarea.add_child(largeslot)
+	

--- a/frontend/Savor-22b/scripts/scenes/intro.gd
+++ b/frontend/Savor-22b/scripts/scenes/intro.gd
@@ -2,13 +2,19 @@ extends Control
 
 func _ready():
 	print("intro scene ready")
+	_all_ready()
+	
+func _all_ready():
 	_query_villages()
 	_query_user_state()
 	_query_assets()
 	_query_shop()
 	_query_recipe()
+	_query_kitchen_slot_state()
 	
-	
+	get_current_block()
+	print("block index")
+	print(SceneContext.block_index)
 
 func _on_quit_button_button_down():
 	print("quit button down")
@@ -149,7 +155,7 @@ func _query_user_state():
 	query_executor.run({
 		"signer_address": GlobalSigner.signer_address
 	})
-	
+
 func _query_shop():
 	var query = GQLQuery.new("shop").set_props([
 		GQLQuery.new("items").set_props([
@@ -211,3 +217,144 @@ func _query_recipe():
 	add_child(query_executor)
 	query_executor.run({})
 
+func _query_kitchen_slot_state():
+	print("signer address: %s" % GlobalSigner.signer_address)
+	
+	var query = GQLQuery.new("userState").set_args({
+		"signer_address": "address",
+	}).set_props([
+		GQLQuery.new("villageState").set_props([
+			GQLQuery.new("houseState").set_props([
+				GQLQuery.new("kitchenState").set_props([
+					GQLQuery.new("firstApplianceSpace").set_props([
+						"spaceNumber",
+						GQLQuery.new("installedKitchenEquipment").set_props([
+							"stateId",
+							"equipmentId",
+							"equipmentName",
+							"blockTimeReductionPercent",
+							"equipmentCategoryId",
+							"equipmentCategoryName",
+							"equipmentCategoryType",
+							"isCooking",
+							"cookingEndBlockIndex",
+							GQLQuery.new("cookingFood").set_props([
+								"stateId",
+								"ingredientId",
+								"foodID",
+								"name",
+								"grade",
+								"hp",
+								"attack",
+								"defense",
+								"speed",
+								"isSuperFood",
+								"level",
+								"isAvailable",
+							]),
+						]),
+					]),
+					GQLQuery.new("secondApplianceSpace").set_props([
+						"spaceNumber",
+						GQLQuery.new("installedKitchenEquipment").set_props([
+							"stateId",
+							"equipmentId",
+							"equipmentName",
+							"blockTimeReductionPercent",
+							"equipmentCategoryId",
+							"equipmentCategoryName",
+							"equipmentCategoryType",
+							"isCooking",
+							"cookingEndBlockIndex",
+							GQLQuery.new("cookingFood").set_props([
+								"stateId",
+								"ingredientId",
+								"foodID",
+								"name",
+								"grade",
+								"hp",
+								"attack",
+								"defense",
+								"speed",
+								"isSuperFood",
+								"level",
+								"isAvailable",
+							]),
+						]),
+					]),
+					GQLQuery.new("thirdApplianceSpace").set_props([
+						"spaceNumber",
+						GQLQuery.new("installedKitchenEquipment").set_props([
+							"stateId",
+							"equipmentId",
+							"equipmentName",
+							"blockTimeReductionPercent",
+							"equipmentCategoryId",
+							"equipmentCategoryName",
+							"equipmentCategoryType",
+							"isCooking",
+							"cookingEndBlockIndex",
+							GQLQuery.new("cookingFood").set_props([
+								"stateId",
+								"ingredientId",
+								"foodID",
+								"name",
+								"grade",
+								"hp",
+								"attack",
+								"defense",
+								"speed",
+								"isSuperFood",
+								"level",
+								"isAvailable",
+							]),
+						]),
+					])
+				]),
+			]),
+		]),
+	])
+	
+	print(query.serialize())
+	
+	var query_executor = SvrGqlClient.query(
+		'query',
+		{
+			"signer_address": "String!",
+		},
+		query
+	)
+	
+	query_executor.graphql_response.connect(
+		func(data):
+			print(data)
+			SceneContext.set_user_kitchen_state(data)
+	)
+	
+	add_child(query_executor)
+	query_executor.run({
+		"signer_address": GlobalSigner.signer_address
+	})
+
+func get_current_block():
+	var query_string = "query
+	{
+		blockQuery
+		{
+			blocks(limit:1, desc:true)
+			{
+				hash
+				index
+			}
+		}
+	}"
+
+	print(query_string)
+	
+	var query_executor = SvrGqlClient2.raw(query_string)
+	query_executor.graphql_response.connect(func(data):
+		print("gql response: ", data)
+		SceneContext.get_current_block(data)
+	)
+	add_child(query_executor)
+	query_executor.run({})


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
집 화면에서 작은/큰 조리도구에 따른 조리중인 요리를 볼 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
조리중인 음식을 보여주되, 큰 조리도구를 설치하여 사용한 요리는 별개로 보이도록 합니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->

<img width="1072" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/b3234102-be31-4384-8835-10a552e690b3">

- 큰 조리도구 조회 코드 추가
- 현재 블록을 조회할 수 있는 클라이언트 코드 추가
- 집 화면의 음식 조리 슬롯 UI 추가
- 부엌 UI에 조리중인 음식의 이름과 남은 블록을 표시

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
<img width="236" alt="image" src="https://github.com/not-blond-beard/Savor-22b/assets/78776542/1a038c06-f13c-4598-b419-e4be71e01a43">


현재 블록 조회를 위하여 클라이언트 코드를 하나 더 만들었습니다.
(나중에 빌드 시에 endpoint를 둘 다 수정해야 합니다)