### PR TITLE
[SVR-297] [던전] 특정 던전의 점령권 반환 예상 보상 READ 기능

### DIFF
--- a/backend/app/Savor22b/DataModel/DungeonReturnReward.cs
+++ b/backend/app/Savor22b/DataModel/DungeonReturnReward.cs
@@ -1,0 +1,11 @@
+namespace Savor22b.DataModel;
+
+public class DungeonReturnReward
+{
+    public string RewardBBG { get; set; }
+
+    public DungeonReturnReward(string rewardBBG)
+    {
+        RewardBBG = rewardBBG;
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Query/DungeonReturnRewardQuery.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/DungeonReturnRewardQuery.cs
@@ -1,0 +1,47 @@
+namespace Savor22b.GraphTypes.Query;
+
+using GraphQL;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Libplanet.Blockchain;
+using Libplanet.Net;
+using Savor22b.DataModel;
+using Savor22b.GraphTypes.Types;
+using Savor22b.Model;
+
+public class DungeonReturnRewardQuery : FieldType
+{
+    public DungeonReturnRewardQuery()
+        : base()
+    {
+        Name = "dungeonReturnReward";
+        Type = typeof(NonNullGraphType<DungeonReturnRewardType>);
+        Description = "특정 던전 점령권을 반환했을 때 얻을 수 있는 보상을 반환합니다. ";
+        Arguments = new QueryArguments(
+            new QueryArgument<NonNullGraphType<IntGraphType>>
+            {
+                Name = "dungeonId",
+                Description = "점령권을 반환할 예정인 던전 Id를 입력합니다. ",
+            }
+        );
+        Resolver = new FuncFieldResolver<DungeonReturnReward>(context =>
+        {
+            try
+            {
+                var dungeonId = context.GetArgument<int>("dungeonId");
+                Dungeon? dungeon = CsvDataHelper.GetDungeonById(dungeonId);
+
+                if (dungeon == null)
+                {
+                    throw new ExecutionError("해당 던전이 존재하지 않습니다. ");
+                }
+
+                return new DungeonReturnReward(dungeon.ReturnDungeonRewardBBG);
+            }
+            catch (Exception e)
+            {
+                throw new ExecutionError(e.Message);
+            }
+        });
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -530,6 +530,7 @@ public class Query : ObjectGraphType
 
         AddField(new DungeonExplorationQuery(blockChain, swarm));
         AddField(new CalculateRelocationCostQuery());
+        AddField(new DungeonReturnRewardQuery());
         AddField(new ShopQuery());
     }
 

--- a/backend/app/Savor22b/GraphTypes/Types/DungeonReturnRewardType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/DungeonReturnRewardType.cs
@@ -1,0 +1,17 @@
+namespace Savor22b.GraphTypes.Types;
+
+using GraphQL.Types;
+using Libplanet.Explorer.GraphTypes;
+using Savor22b.DataModel;
+
+public class DungeonReturnRewardType : ObjectGraphType<DungeonReturnReward>
+{
+    public DungeonReturnRewardType()
+    {
+        Field<NonNullGraphType<StringGraphType>>(
+            "rewardBBG",
+            description: "던전 점령권 반환 시 획득 가능한 BBG입니다. ",
+            resolve: context => context.Source.RewardBBG
+        );
+    }
+}

--- a/backend/app/Savor22b/Model/Dungeon.cs
+++ b/backend/app/Savor22b/Model/Dungeon.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Bencodex.Types;
 using Libplanet;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Savor22b.Constants;
 using Savor22b.States;
@@ -15,6 +16,12 @@ public class Dungeon
     public int ID { get; set; }
     public int VillageId { get; set; }
     public ImmutableList<int> RewardSeedIdList { get; set; }
+    public string ReturnDungeonRewardBBG { get; set; }
+
+    public FungibleAssetValue PriceToFungibleAssetValue()
+    {
+        return FungibleAssetValue.Parse(Currencies.KeyCurrency, ReturnDungeonRewardBBG);
+    }
 
     private static GlobalDungeonState GetGlobalDungeonState(BlockChain blockChain)
     {

--- a/resources/savor22b/tabledata/dungeon.csv
+++ b/resources/savor22b/tabledata/dungeon.csv
@@ -1,4 +1,4 @@
-Name,X,Y,ID,VillageId,RewardSeedIdList
-땅콩 던전,0,1,0,1,1;2;3;4;5
-빵 던전,2,3,1,2,5;6;7;8;9
-케이크 던전,2,5,2,3,1;2;3;6;7;8
+Name,X,Y,ID,VillageId,RewardSeedIdList,ReturnDungeonRewardBBG
+땅콩 던전,0,1,0,1,1;2;3;4;5,500
+빵 던전,2,3,1,2,5;6;7;8;9,1000
+케이크 던전,2,5,2,3,1;2;3;6;7;8,700


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 특정 던전의 점령권 반환 예상 보상 READ 기능 제작

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
![image](https://github.com/not-blond-beard/Savor-22b/assets/56328777/465b60ff-fed7-4ead-a2bb-e8bc6dd0c1af)
