### PR TITLE
[SVR-180] [밭] 유저 액션 기능

### DIFF
--- a/frontend/Savor-22b/gql/query.gd
+++ b/frontend/Savor-22b/gql/query.gd
@@ -48,6 +48,14 @@ var remove_seed_query_format = "query {
 	)
 }"
 
+var remove_weed_query_format = "query {
+	createAction_RemoveWeed(
+		publicKey: {},
+		fieldIndex: {}
+	)
+}"
+
+
 
 var buy_shop_item_query_format = "query {
 	createAction_BuyShopItem(

--- a/frontend/Savor-22b/ui/farm_action_popup.gd
+++ b/frontend/Savor-22b/ui/farm_action_popup.gd
@@ -1,11 +1,15 @@
 extends ColorRect
 
 signal button_down_remove
+signal weed_action_signal
 
 
 func _ready():
 	pass # Replace with function body.
 
+func set_weed_button(weed : bool):
+	if (weed):
+		$M/V/Weed.visible = true
 
 func _on_remove_button_down():
 	button_down_remove.emit()
@@ -13,4 +17,9 @@ func _on_remove_button_down():
 
 
 func _on_cancel_button_down():
+	queue_free()
+
+
+func _on_weed_button_down():
+	weed_action_signal.emit()
 	queue_free()

--- a/frontend/Savor-22b/ui/farm_action_popup.tscn
+++ b/frontend/Savor-22b/ui/farm_action_popup.tscn
@@ -6,9 +6,9 @@
 bg_color = Color(0, 0, 0, 1)
 
 [node name="ActionPopup" type="ColorRect"]
-custom_minimum_size = Vector2(400, 100)
+custom_minimum_size = Vector2(400, 200)
 offset_right = 400.0
-offset_bottom = 200.0
+offset_bottom = 300.0
 color = Color(0.866667, 0.498039, 0.215686, 1)
 script = ExtResource("1_ma8qk")
 
@@ -34,6 +34,14 @@ theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxFlat_yesvl")
 text = "종자 제거하기"
 
+[node name="Weed" type="Button" parent="M/V"]
+visible = false
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 1, 0, 1)
+theme_override_font_sizes/font_size = 50
+theme_override_styles/normal = SubResource("StyleBoxFlat_yesvl")
+text = "잡초 제거하기"
+
 [node name="Cancel" type="Button" parent="M/V"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 50
@@ -41,4 +49,5 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_yesvl")
 text = "행동 취소"
 
 [connection signal="button_down" from="M/V/Remove" to="." method="_on_remove_button_down"]
+[connection signal="button_down" from="M/V/Weed" to="." method="_on_weed_button_down"]
 [connection signal="button_down" from="M/V/Cancel" to="." method="_on_cancel_button_down"]

--- a/frontend/Savor-22b/ui/farm_slot_button.gd
+++ b/frontend/Savor-22b/ui/farm_slot_button.gd
@@ -2,7 +2,7 @@ extends ColorRect
 
 signal button_down(child_index: int)
 signal button_down_action
-signal weed_action
+
 
 @onready var button = $V/Button
 
@@ -25,7 +25,7 @@ func _update_button():
 	button.text = format_string % [farm_slot.seedName, "자라는 중", timeleft, "블록 남음"]
 	
 	if (farm_slot.weedRemovalAble):
-		pass
+		$Weed.visible = true
 
 func set_farm_slot(farm_slot: Dictionary):
 	self.farm_slot = farm_slot
@@ -36,7 +36,7 @@ func _on_button_button_down():
 		button_down.emit(get_index())
 	else:
 		button_down.emit(get_index()+5)
-	button_down_action.emit()
+	button_down_action.emit(farm_slot.weedRemovalAble)
 
 
 func im_right():

--- a/frontend/Savor-22b/ui/farm_slot_button.gd
+++ b/frontend/Savor-22b/ui/farm_slot_button.gd
@@ -2,6 +2,7 @@ extends ColorRect
 
 signal button_down(child_index: int)
 signal button_down_action
+signal weed_action
 
 @onready var button = $V/Button
 
@@ -18,9 +19,13 @@ func _ready():
 func _update_button():
 	if button == null:
 		return
-
-	button.text = format_string % [farm_slot.seedName, "자라는 중", farm_slot.totalBlock, "블록 남음"]
+		
+	var currenttime = SceneContext.block_index["blockQuery"]["blocks"][0]["index"]
+	var timeleft = (farm_slot.installedBlock + farm_slot.totalBlock) - currenttime
+	button.text = format_string % [farm_slot.seedName, "자라는 중", timeleft, "블록 남음"]
 	
+	if (farm_slot.weedRemovalAble):
+		pass
 
 func set_farm_slot(farm_slot: Dictionary):
 	self.farm_slot = farm_slot

--- a/frontend/Savor-22b/ui/farm_slot_button.tscn
+++ b/frontend/Savor-22b/ui/farm_slot_button.tscn
@@ -38,14 +38,18 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_ctkwv")
 text = "[벼] 자라는 중
 [N 블록 남음]"
 
-[node name="Label" type="Label" parent="V/Button"]
-layout_mode = 2
-offset_top = 245.0
-offset_right = 500.0
-offset_bottom = 300.0
+[node name="Weed" type="Label" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_colors/font_color = Color(0, 1, 0, 1)
-theme_override_font_sizes/font_size = 40
+theme_override_font_sizes/font_size = 28
 text = "[잡초 제거 필요]"
-horizontal_alignment = 1
+horizontal_alignment = 2
+vertical_alignment = 2
 
 [connection signal="button_down" from="V/Button" to="." method="_on_button_button_down"]


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
밭에서 자라고 있는 종자의 잡초를 제거할 수 있습니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
자라고 있는 종자를 클릭하면 액션 팝업이 뜹니다.
잡초가 자란 경우 종자 우하단에 잡초 제거 필요 표시가 뜹니다.
잡초가 자란 경우 액션 팝업에서 잡초 제거하기 버튼이 추가됩니다.
버튼을 누를 경우 잡초가 제거됩니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
![image](https://github.com/not-blond-beard/Savor-22b/assets/78776542/3dff4058-9118-457c-aa86-ff3dc506f41d)

![image](https://github.com/not-blond-beard/Savor-22b/assets/78776542/f8221a4f-813a-4f0a-b197-f41e375ad38a)

![image](https://github.com/not-blond-beard/Savor-22b/assets/78776542/d6a1eb76-fd5b-443c-94ed-7b2304bcc157)


