### PR TITLE
[SVR-296] [던전] 던전 점령 플레이어의 주기적 보상 제공 기능

### DIFF
--- a/backend/app/Savor22b.Tests/Action/ExplorationDungeonActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/ExplorationDungeonActionTests.cs
@@ -68,7 +68,11 @@ public class ExplorationDungeonActionTests : ActionTests
         IAccountStateDelta beforeState = new DummyState();
         var state = new RootState(
             new InventoryState(),
-            new UserDungeonState(dungeonHistories, ImmutableList<DungeonConquestHistoryState>.Empty)
+            new UserDungeonState(
+                dungeonHistories,
+                ImmutableList<DungeonConquestHistoryState>.Empty,
+                ImmutableList<DungeonConquestPeriodicRewardHistoryState>.Empty
+            )
         );
         beforeState = beforeState.SetState(SignerAddress(), state.Serialize());
 
@@ -123,7 +127,11 @@ public class ExplorationDungeonActionTests : ActionTests
         IAccountStateDelta beforeState = new DummyState();
         var state = new RootState(
             new InventoryState(),
-            new UserDungeonState(dungeonHistories, ImmutableList<DungeonConquestHistoryState>.Empty)
+            new UserDungeonState(
+                dungeonHistories,
+                ImmutableList<DungeonConquestHistoryState>.Empty,
+                ImmutableList<DungeonConquestPeriodicRewardHistoryState>.Empty
+            )
         );
         beforeState = beforeState.SetState(SignerAddress(), state.Serialize());
 

--- a/backend/app/Savor22b.Tests/Action/PeriodicDungeonRewardActionTests.cs
+++ b/backend/app/Savor22b.Tests/Action/PeriodicDungeonRewardActionTests.cs
@@ -1,0 +1,165 @@
+namespace Savor22b.Tests.Action;
+
+using System;
+using System.Collections.Immutable;
+using Libplanet;
+using Libplanet.State;
+using Savor22b.Action;
+using Savor22b.Action.Exceptions;
+using Savor22b.Constants;
+using Savor22b.States;
+using Xunit;
+
+public class PeriodicDungeonRewardActionTests : ActionTests
+{
+    public static int TestDungeonId = 0;
+
+    public PeriodicDungeonRewardActionTests() { }
+
+    [Fact]
+    public void Execute_Success_Normal()
+    {
+        long currentBlock = 402;
+
+        IAccountStateDelta beforeState = new DummyState();
+        var state = new RootState(
+            new InventoryState(),
+            new UserDungeonState(
+                ImmutableList.Create(
+                    new DungeonHistoryState(1, TestDungeonId, 1, ImmutableList<int>.Empty)
+                ),
+                ImmutableList.Create(new DungeonConquestHistoryState(1, TestDungeonId, 1)),
+                ImmutableList.Create(
+                    new DungeonConquestPeriodicRewardHistoryState(
+                        105,
+                        TestDungeonId,
+                        ImmutableList.Create(1, 2, 3)
+                    ),
+                    new DungeonConquestPeriodicRewardHistoryState(
+                        205,
+                        TestDungeonId,
+                        ImmutableList.Create(1, 2, 3)
+                    )
+                )
+            )
+        );
+
+        GlobalDungeonState globalDungeonState = new GlobalDungeonState(
+            new Dictionary<string, Address> { [TestDungeonId.ToString()] = SignerAddress() }
+        );
+
+        beforeState = beforeState
+            .SetState(SignerAddress(), state.Serialize())
+            .SetState(Addresses.DungeonDataAddress, globalDungeonState.Serialize());
+
+        PeriodicDungeonRewardAction action = new PeriodicDungeonRewardAction(TestDungeonId);
+
+        IAccountStateDelta afterState = action.Execute(
+            new DummyActionContext
+            {
+                PreviousStates = beforeState,
+                Signer = SignerAddress(),
+                Random = random,
+                Rehearsal = false,
+                BlockIndex = currentBlock,
+            }
+        );
+
+        Bencodex.Types.IValue? afterRootStateEncoded = afterState.GetState(SignerAddress());
+        RootState afterRootState = afterRootStateEncoded is Bencodex.Types.Dictionary bdict
+            ? new RootState(bdict)
+            : throw new Exception();
+        UserDungeonState userDungeonState = afterRootState.UserDungeonState;
+
+        Assert.Equal(
+            0,
+            userDungeonState.PresentDungeonPeriodicRewardCount(TestDungeonId, 1, currentBlock)
+        );
+        Assert.Equal(4, userDungeonState.DungeonConquestPeriodicRewardHistories.Count);
+        Assert.Equal(5 * 2, afterRootState.InventoryState.SeedStateList.Count);
+    }
+
+    [Fact]
+    public void Execute_Fail_NotConquest()
+    {
+        IAccountStateDelta beforeState = new DummyState();
+        var state = new RootState(
+            new InventoryState(),
+            new UserDungeonState(
+                ImmutableList.Create(new DungeonHistoryState(1, 2, 1, ImmutableList<int>.Empty)),
+                ImmutableList.Create(new DungeonConquestHistoryState(1, 2, 1)),
+                ImmutableList<DungeonConquestPeriodicRewardHistoryState>.Empty
+            )
+        );
+        beforeState = beforeState.SetState(SignerAddress(), state.Serialize());
+
+        PeriodicDungeonRewardAction action = new PeriodicDungeonRewardAction(TestDungeonId);
+
+        Assert.Throws<PermissionDeniedException>(
+            () =>
+                action.Execute(
+                    new DummyActionContext
+                    {
+                        PreviousStates = beforeState,
+                        Signer = SignerAddress(),
+                        Random = random,
+                        Rehearsal = false,
+                        BlockIndex = 200,
+                    }
+                )
+        );
+    }
+
+    [Fact]
+    public void Execute_Fail_AlreadyReceive()
+    {
+        long currentBlock = 299;
+
+        IAccountStateDelta beforeState = new DummyState();
+        var state = new RootState(
+            new InventoryState(),
+            new UserDungeonState(
+                ImmutableList.Create(
+                    new DungeonHistoryState(1, TestDungeonId, 1, ImmutableList<int>.Empty)
+                ),
+                ImmutableList.Create(new DungeonConquestHistoryState(1, TestDungeonId, 1)),
+                ImmutableList.Create(
+                    new DungeonConquestPeriodicRewardHistoryState(
+                        105,
+                        TestDungeonId,
+                        ImmutableList.Create(1, 2, 3)
+                    ),
+                    new DungeonConquestPeriodicRewardHistoryState(
+                        205,
+                        TestDungeonId,
+                        ImmutableList.Create(1, 2, 3)
+                    )
+                )
+            )
+        );
+
+        GlobalDungeonState globalDungeonState = new GlobalDungeonState(
+            new Dictionary<string, Address> { [TestDungeonId.ToString()] = SignerAddress() }
+        );
+
+        beforeState = beforeState
+            .SetState(SignerAddress(), state.Serialize())
+            .SetState(Addresses.DungeonDataAddress, globalDungeonState.Serialize());
+
+        PeriodicDungeonRewardAction action = new PeriodicDungeonRewardAction(TestDungeonId);
+
+        Assert.Throws<ResourceIsNotReadyException>(
+            () =>
+                action.Execute(
+                    new DummyActionContext
+                    {
+                        PreviousStates = beforeState,
+                        Signer = SignerAddress(),
+                        Random = random,
+                        Rehearsal = false,
+                        BlockIndex = currentBlock,
+                    }
+                )
+        );
+    }
+}

--- a/backend/app/Savor22b/Action/Exceptions/AlreadyRequestedException.cs
+++ b/backend/app/Savor22b/Action/Exceptions/AlreadyRequestedException.cs
@@ -1,0 +1,8 @@
+namespace Savor22b.Action.Exceptions;
+
+[Serializable]
+public class AlreadyRequestedException : ActionException
+{
+    public AlreadyRequestedException(string message, int? errorCode = null)
+        : base(message, "AlreadyRequested", errorCode) { }
+}

--- a/backend/app/Savor22b/Action/Exceptions/ResourceIsNotReadyException.cs
+++ b/backend/app/Savor22b/Action/Exceptions/ResourceIsNotReadyException.cs
@@ -1,0 +1,8 @@
+namespace Savor22b.Action.Exceptions;
+
+[Serializable]
+public class ResourceIsNotReadyException : ActionException
+{
+    public ResourceIsNotReadyException(string message, int? errorCode = null)
+        : base(message, "ResourceIsNotReady", errorCode) { }
+}

--- a/backend/app/Savor22b/Action/PeriodicDungeonRewardAction.cs
+++ b/backend/app/Savor22b/Action/PeriodicDungeonRewardAction.cs
@@ -1,0 +1,127 @@
+namespace Savor22b.Action;
+
+using System;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Headless.Extensions;
+using Libplanet.State;
+using Savor22b.Action.Util;
+using Savor22b.Action.Exceptions;
+using Savor22b.States;
+using Savor22b.Model;
+using Libplanet.Blockchain;
+using Savor22b.Constants;
+
+[ActionType(nameof(PeriodicDungeonRewardAction))]
+public class PeriodicDungeonRewardAction : SVRAction
+{
+    public PeriodicDungeonRewardAction() { }
+
+    public PeriodicDungeonRewardAction(int dungeonId)
+    {
+        DungeonId = dungeonId;
+    }
+
+    public int DungeonId { get; private set; }
+
+    protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+        new Dictionary<string, IValue>()
+        {
+            [nameof(DungeonId)] = DungeonId.Serialize(),
+        }.ToImmutableDictionary();
+
+    protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+    {
+        DungeonId = plainValue[nameof(DungeonId)].ToInteger();
+    }
+
+    private List<SeedState> GenerateSeedStates(IRandom random, ImmutableList<int> seedIds)
+    {
+        List<SeedState> seedStates = new List<SeedState>();
+
+        foreach (int seedId in seedIds)
+        {
+            seedStates.Add(new SeedState(random.GenerateRandomGuid(), seedId));
+        }
+
+        return seedStates;
+    }
+
+    public override IAccountStateDelta Execute(IActionContext ctx)
+    {
+        if (ctx.Rehearsal)
+        {
+            return ctx.PreviousStates;
+        }
+
+        Validation.EnsureDungeonExist(DungeonId);
+
+        IAccountStateDelta states = ctx.PreviousStates;
+
+        GlobalDungeonState globalDungeonState = states.GetState(Addresses.DungeonDataAddress)
+            is Dictionary encoded
+            ? new GlobalDungeonState(encoded)
+            : new GlobalDungeonState();
+        RootState rootState = states.GetState(ctx.Signer) is Dictionary rootStateEncoded
+            ? new RootState(rootStateEncoded)
+            : new RootState();
+        UserDungeonState userDungeonState = rootState.UserDungeonState;
+        InventoryState inventoryState = rootState.InventoryState;
+
+        if (!globalDungeonState.IsDungeonConquestAddress(DungeonId, ctx.Signer))
+        {
+            throw new PermissionDeniedException(
+                $"The dungeon {DungeonId} has not been conquered by the signer."
+            );
+        }
+
+        DungeonConquestHistoryState? history = userDungeonState.CurrentConquestDungeonHistory(
+            DungeonId
+        );
+
+        if (history is null)
+        {
+            throw new PermissionDeniedException(
+                $"The dungeon {DungeonId} has not been conquered by the signer."
+            );
+        }
+
+        int dungeonPeriodicRewardCount = userDungeonState.PresentDungeonPeriodicRewardCount(
+            DungeonId,
+            history.BlockIndex,
+            ctx.BlockIndex
+        );
+
+        if (dungeonPeriodicRewardCount <= 0)
+        {
+            throw new ResourceIsNotReadyException(
+                $"You need to wait blocks to get the periodic reward."
+            );
+        }
+
+        Dungeon dungeon = CsvDataHelper.GetDungeonById(DungeonId)!;
+
+        for (int i = 0; i < dungeonPeriodicRewardCount; i++)
+        {
+            DungeonConquestPeriodicRewardHistoryState periodicRewardHistory =
+                new DungeonConquestPeriodicRewardHistoryState(
+                    ctx.BlockIndex,
+                    DungeonId,
+                    dungeon.RewardSeedIdList
+                );
+
+            userDungeonState = userDungeonState.AddDungeonPeriodicRewardHistory(
+                periodicRewardHistory
+            );
+            inventoryState = inventoryState.AddSeeds(
+                GenerateSeedStates(ctx.Random, dungeon.RewardSeedIdList)
+            );
+        }
+
+        rootState.SetUserDungeonState(userDungeonState);
+        rootState.SetInventoryState(inventoryState);
+
+        return states.SetState(ctx.Signer, rootState.Serialize());
+    }
+}

--- a/backend/app/Savor22b/Action/Util/Validation.cs
+++ b/backend/app/Savor22b/Action/Util/Validation.cs
@@ -36,4 +36,14 @@ public static class Validation
 
         return village;
     }
+
+    public static void EnsureDungeonExist(int dungeonId)
+    {
+        Dungeon? dungeon = CsvDataHelper.GetDungeonById(dungeonId);
+
+        if (dungeon == null)
+        {
+            throw new InvalidDungeonException($"Invalid dungeon ID: {dungeonId}");
+        }
+    }
 }

--- a/backend/app/Savor22b/GraphTypes/Query/PeriodicDungeonRewardActionQuery.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/PeriodicDungeonRewardActionQuery.cs
@@ -1,0 +1,54 @@
+namespace Savor22b.GraphTypes.Query;
+
+using GraphQL;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Libplanet.Blockchain;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Savor22b.Action;
+
+public class PeriodicDungeonRewardActionQuery : FieldType
+{
+    public PeriodicDungeonRewardActionQuery(BlockChain blockChain, Swarm swarm)
+        : base()
+    {
+        Name = "createAction_PeriodicDungeonRewardAction";
+        Type = typeof(NonNullGraphType<StringGraphType>);
+        Description = "점령한 던전에 대한 주기적인 보상을 받습니다.";
+        Arguments = new QueryArguments(
+            new QueryArgument<NonNullGraphType<StringGraphType>>
+            {
+                Name = "publicKey",
+                Description = "대상 유저의 40-hex 형태의 address 입니다.",
+            },
+            new QueryArgument<NonNullGraphType<IntGraphType>>
+            {
+                Name = "dungeonId",
+                Description = "보상을 받는 대상 던전의 ID 입니다.",
+            }
+        );
+        Resolver = new FuncFieldResolver<string>(context =>
+        {
+            try
+            {
+                var publicKey = new PublicKey(
+                    Libplanet.ByteUtil.ParseHex(context.GetArgument<string>("publicKey"))
+                );
+
+                var action = new PeriodicDungeonRewardAction(context.GetArgument<int>("dungeonId"));
+
+                return new GetUnsignedTransactionHex(
+                    action,
+                    publicKey,
+                    blockChain,
+                    swarm
+                ).UnsignedTransactionHex;
+            }
+            catch (Exception e)
+            {
+                throw new ExecutionError(e.Message);
+            }
+        });
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -725,6 +725,7 @@ public class Query : ObjectGraphType
         AddField(new ShowMeTheMoney(blockChain, swarm));
         AddField(new ConquestDungeonActionQuery(blockChain, swarm));
         AddField(new RemoveInstalledKitchenEquipmentActionQuery(blockChain, swarm));
+        AddField(new PeriodicDungeonRewardActionQuery(blockChain, swarm));
     }
 
     private List<RecipeResponse> combineRecipeData()

--- a/backend/app/Savor22b/States/DungeonConquestPeriodicRewardHistoryState.cs
+++ b/backend/app/Savor22b/States/DungeonConquestPeriodicRewardHistoryState.cs
@@ -1,0 +1,47 @@
+namespace Savor22b.States;
+
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Headless.Extensions;
+
+public class DungeonConquestPeriodicRewardHistoryState : State
+{
+    public DungeonConquestPeriodicRewardHistoryState(
+        long blockIndex,
+        int dungeonId,
+        ImmutableList<int> rewardSeedIdList
+    )
+    {
+        BlockIndex = blockIndex;
+        DungeonId = dungeonId;
+        RewardSeedIdList = rewardSeedIdList;
+    }
+
+    public DungeonConquestPeriodicRewardHistoryState(Dictionary encoded)
+    {
+        BlockIndex = encoded[nameof(BlockIndex)].ToLong();
+        DungeonId = encoded[nameof(DungeonId)].ToInteger();
+        RewardSeedIdList = ((List)encoded[nameof(RewardSeedIdList)])
+            .Select(e => e.ToInteger())
+            .ToImmutableList();
+    }
+
+    public long BlockIndex { get; private set; }
+    public int DungeonId { get; private set; }
+    public ImmutableList<int> RewardSeedIdList { get; private set; }
+
+    public IValue Serialize()
+    {
+        var pairs = new[]
+        {
+            new KeyValuePair<IKey, IValue>((Text)nameof(BlockIndex), BlockIndex.Serialize()),
+            new KeyValuePair<IKey, IValue>((Text)nameof(DungeonId), DungeonId.Serialize()),
+            new KeyValuePair<IKey, IValue>(
+                (Text)nameof(RewardSeedIdList),
+                new List(RewardSeedIdList.Select(e => e.Serialize()))
+            ),
+        };
+
+        return new Dictionary(pairs);
+    }
+}

--- a/backend/app/Savor22b/States/GlobalDungeonState.cs
+++ b/backend/app/Savor22b/States/GlobalDungeonState.cs
@@ -63,4 +63,10 @@ public class GlobalDungeonState : State
         DungeonStatus[dungeonId.ToString()] = address;
         return new GlobalDungeonState(DungeonStatus);
     }
+
+    public bool IsDungeonConquestAddress(int dungeonId, Address address)
+    {
+        return DungeonStatus.TryGetValue(dungeonId.ToString(), out Address conquestAddress)
+            && conquestAddress == address;
+    }
 }

--- a/backend/app/Savor22b/States/InventoryState.cs
+++ b/backend/app/Savor22b/States/InventoryState.cs
@@ -134,6 +134,17 @@ public class InventoryState : State
         );
     }
 
+    public InventoryState AddSeeds(IEnumerable<SeedState> seedStates)
+    {
+        var seedStateList = SeedStateList.AddRange(seedStates);
+        return new InventoryState(
+            seedStateList,
+            RefrigeratorStateList,
+            KitchenEquipmentStateList,
+            ItemStateList
+        );
+    }
+
     public InventoryState AddRefrigeratorItem(RefrigeratorState item)
     {
         var refrigeratorStateList = RefrigeratorStateList.Add(item);


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->
- 사용자에게 던전 점령 시 주기적인 보상을 제공합니다.

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 정기적으로 노드 측에서 보상을 제공하는 방식을 생각했으나,
- 구현상의 어려움과 빠른 개발을 위해 사용자가 직접 신청하면 보상을 제공하는 식으로 진행합니다.
- 받아야 할 시기를 놓쳐도 한번에 받을 수 있습니다.
- 보상의 경우, 던전을 클리어 했을때 받는 보상을 또 받고 있습니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
![image](https://github.com/not-blond-beard/Savor-22b/assets/56328777/bbfe630e-9229-4a09-88a7-2d6d1a35a9ce)

# 리뷰어가 중점적으로 볼 사항
<!--
리뷰어에게 전달할 사항을 적어주세요.

예시: 포매팅 변경이 있어서 diff가 많지만, 유의미한 변경이 아니니 -- 기능 위주로만 봐주시면 됩니다.
예시: 이번에 ---한 변경사항이 있어서, 기존 작업됐던 --- 내용들이 영향을 받습니다. 그래서 ---한 변경이 있으니 이 부분을 ---한지 봐주시면 됩니다. 
-->
- 이번 액션말고 다른 액션 테스트 코드 수정은 다른 테스트 코드가 참조하고 있던 생성자 부분을 좀 바꿔서 그렇습니다 신경 안쓰셔도 됩니다
