### PR TITLE
[SVR-322] [던전] 특정 유저의 던전 정보 READ 기능

### DIFF
--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -726,6 +726,30 @@ public class Query : ObjectGraphType
         AddField(new ConquestDungeonActionQuery(blockChain, swarm));
         AddField(new RemoveInstalledKitchenEquipmentActionQuery(blockChain, swarm));
         AddField(new PeriodicDungeonRewardActionQuery(blockChain, swarm));
+
+        Field<NonNullGraphType<IntGraphType>>(
+            name: "maxDungeonKeyCount",
+            description: "던전 키의 최대 개수입니다.",
+            resolve: context => UserDungeonState.MaxDungeonConquestKeyCount
+        );
+
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "dungeonKeyChargeIntervalBlock",
+            description: "던전 키의 충전 주기(Block)입니다.",
+            resolve: context => UserDungeonState.DungeonKeyChargeIntervalBlock
+        );
+
+        Field<NonNullGraphType<IntGraphType>>(
+            name: "maxDungeonConquestKeyCount",
+            description: "던전 점령 키(던전마다 할당)의 최대 개수입니다.",
+            resolve: context => UserDungeonState.MaxDungeonConquestKeyCount
+        );
+
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "dungeonConquestKeyChargeIntervalBlock",
+            description: "던전 점령 키(던전마다 할당)의 충전 주기(Block)입니다.",
+            resolve: context => UserDungeonState.DungeonConquestKeyChargeIntervalBlock
+        );
     }
 
     private List<RecipeResponse> combineRecipeData()

--- a/backend/app/Savor22b/GraphTypes/Query/Query.cs
+++ b/backend/app/Savor22b/GraphTypes/Query/Query.cs
@@ -730,7 +730,7 @@ public class Query : ObjectGraphType
         Field<NonNullGraphType<IntGraphType>>(
             name: "maxDungeonKeyCount",
             description: "던전 키의 최대 개수입니다.",
-            resolve: context => UserDungeonState.MaxDungeonConquestKeyCount
+            resolve: context => UserDungeonState.MaxDungeonKey
         );
 
         Field<NonNullGraphType<LongGraphType>>(

--- a/backend/app/Savor22b/GraphTypes/Types/DungeonConquestHistoryStateType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/DungeonConquestHistoryStateType.cs
@@ -1,0 +1,22 @@
+namespace Savor22b.GraphTypes.Types;
+
+using GraphQL.Types;
+using Savor22b.States;
+
+public class DungeonConquestHistoryStateType : ObjectGraphType<DungeonConquestHistoryState>
+{
+    public DungeonConquestHistoryStateType()
+    {
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "BlockIndex",
+            description: "던전 점령을 신청한 블록의 인덱스입니다.",
+            resolve: context => context.Source.BlockIndex
+        );
+
+        Field<NonNullGraphType<BooleanGraphType>>(
+            name: "DungeonConquestStatus",
+            description: "던전의 점령 신청이 성공했는지 여부입니다.",
+            resolve: context => context.Source.DungeonConquestStatus
+        );
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Types/DungeonHistoryStateType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/DungeonHistoryStateType.cs
@@ -1,0 +1,22 @@
+namespace Savor22b.GraphTypes.Types;
+
+using GraphQL.Types;
+using Savor22b.States;
+
+public class DungeonHistoryStateType : ObjectGraphType<DungeonHistoryState>
+{
+    public DungeonHistoryStateType()
+    {
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "BlockIndex",
+            description: "던전 클리어를 신청한 블록 인덱스입니다.",
+            resolve: context => context.Source.BlockIndex
+        );
+
+        Field<NonNullGraphType<BooleanGraphType>>(
+            name: "DungeonClearStatus",
+            description: "던전 클리어 결과입니다.",
+            resolve: context => context.Source.DungeonClearStatus
+        );
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
@@ -1,0 +1,43 @@
+namespace Savor22b.GraphTypes.Types;
+
+using GraphQL;
+using GraphQL.Types;
+using Libplanet.Blockchain;
+using Libplanet.Net;
+using Libplanet.Store;
+using Savor22b.States;
+
+public class UserDungeonDetailType : ObjectGraphType<UserDungeonState>
+{
+    public UserDungeonDetailType(
+        BlockChain blockChain,
+        BlockRenderer blockRenderer,
+        IStore store,
+        Swarm? swarm = null
+    )
+    {
+        Field<BooleanGraphType>(
+            name: "IsDungeonConquestRewardReceivable",
+            description: "점령한 던전의 주기적 보상을 받을 수 있는지 여부를 반환합니다. 점령한 던전이 아니라면 null을 반환합니다.",
+            resolve: context =>
+            {
+                int dungeonId = context.GetArgument<int>("dungeonId");
+
+                DungeonConquestHistoryState? history = context.Source.CurrentConquestDungeonHistory(
+                    dungeonId
+                );
+
+                if (history is null)
+                {
+                    return null;
+                }
+
+                return context.Source.IsDungeonConquestRewardReceivable(
+                    dungeonId,
+                    history.BlockIndex,
+                    blockChain.Count
+                );
+            }
+        );
+    }
+}

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
@@ -55,5 +55,11 @@ public class UserDungeonDetailType : ObjectGraphType<UserDungeonState>
             description: "던전의 탐험 기록(클리어 기록)을 반환합니다.",
             resolve: context => context.Source.DungeonHistories
         );
+
+        Field<NonNullGraphType<ListGraphType<DungeonConquestHistoryStateType>>>(
+            name: "DungeonConquestHistories",
+            description: "던전의 점령 기록을 반환합니다.",
+            resolve: context => context.Source.DungeonConquestHistories
+        );
     }
 }

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
@@ -16,6 +16,16 @@ public class UserDungeonDetailType : ObjectGraphType<UserDungeonState>
         Swarm? swarm = null
     )
     {
+        Field<NonNullGraphType<IntGraphType>>(
+            name: "DungeonConquestKeyCount",
+            description: "해당 던전에 점령 신청 할 수 있는 키의 남은 갯수입니다.",
+            resolve: context =>
+            {
+                int dungeonId = context.GetArgument<int>("dungeonId");
+                return context.Source.GetDungeonConquestKeyCount(dungeonId, blockChain.Count);
+            }
+        );
+
         Field<BooleanGraphType>(
             name: "IsDungeonConquestRewardReceivable",
             description: "점령한 던전의 주기적 보상을 받을 수 있는지 여부를 반환합니다. 점령한 던전이 아니라면 null을 반환합니다.",

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonDetailType.cs
@@ -49,5 +49,11 @@ public class UserDungeonDetailType : ObjectGraphType<UserDungeonState>
                 );
             }
         );
+
+        Field<NonNullGraphType<ListGraphType<DungeonHistoryStateType>>>(
+            name: "DungeonHistories",
+            description: "던전의 탐험 기록(클리어 기록)을 반환합니다.",
+            resolve: context => context.Source.DungeonHistories
+        );
     }
 }

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
@@ -1,5 +1,6 @@
 namespace Savor22b.GraphTypes.Types;
 
+using System.Collections.Immutable;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet;
@@ -24,34 +25,19 @@ public class UserDungeonStateType : ObjectGraphType<UserDungeonState>
             resolve: context => context.Source.GetDungeonKeyCount(blockChain.Count)
         );
 
-        Field<BooleanGraphType>(
-            name: "IsDungeonConquestRewardReceivable",
-            description: "점령한 던전의 주기적 보상을 받을 수 있는지 여부를 반환합니다. 점령한 던전이 아니라면 null을 반환합니다.",
+        Field<NonNullGraphType<UserDungeonDetailType>>(
+            name: "DungeonDetail",
+            description: "특정 던전에 대한(유저의) 상세 정보입니다.",
             arguments: new QueryArguments(
                 new QueryArgument<NonNullGraphType<IntGraphType>>
                 {
                     Name = "dungeonId",
-                    Description = "보상을 받고자 하는 던전(점령한)의 ID",
+                    Description = "조회할 던전의 ID입니다.",
                 }
             ),
             resolve: context =>
             {
-                int dungeonId = context.GetArgument<int>("dungeonId");
-
-                DungeonConquestHistoryState? history = context.Source.CurrentConquestDungeonHistory(
-                    dungeonId
-                );
-
-                if (history is null)
-                {
-                    return null;
-                }
-
-                return context.Source.IsDungeonConquestRewardReceivable(
-                    dungeonId,
-                    history.BlockIndex,
-                    blockChain.Count
-                );
+                return context.Source;
             }
         );
     }

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
@@ -25,18 +25,6 @@ public class UserDungeonStateType : ObjectGraphType<UserDungeonState>
             resolve: context => context.Source.GetDungeonKeyCount(blockChain.Count)
         );
 
-        Field<NonNullGraphType<IntGraphType>>(
-            name: "MaxDungeonKeyCount",
-            description: "던전 키의 최대 개수입니다.",
-            resolve: context => UserDungeonState.MaxDungeonConquestKeyCount
-        );
-
-        Field<NonNullGraphType<LongGraphType>>(
-            name: "DungeonKeyChargeIntervalBlock",
-            description: "던전 키의 충전 주기(Block)입니다.",
-            resolve: context => UserDungeonState.DungeonKeyChargeIntervalBlock
-        );
-
         Field<NonNullGraphType<UserDungeonDetailType>>(
             name: "DungeonDetail",
             description: "특정 던전에 대한(유저의) 상세 정보입니다.",

--- a/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
+++ b/backend/app/Savor22b/GraphTypes/Types/UserDungeonStateType.cs
@@ -25,6 +25,18 @@ public class UserDungeonStateType : ObjectGraphType<UserDungeonState>
             resolve: context => context.Source.GetDungeonKeyCount(blockChain.Count)
         );
 
+        Field<NonNullGraphType<IntGraphType>>(
+            name: "MaxDungeonKeyCount",
+            description: "던전 키의 최대 개수입니다.",
+            resolve: context => UserDungeonState.MaxDungeonConquestKeyCount
+        );
+
+        Field<NonNullGraphType<LongGraphType>>(
+            name: "DungeonKeyChargeIntervalBlock",
+            description: "던전 키의 충전 주기(Block)입니다.",
+            resolve: context => UserDungeonState.DungeonKeyChargeIntervalBlock
+        );
+
         Field<NonNullGraphType<UserDungeonDetailType>>(
             name: "DungeonDetail",
             description: "특정 던전에 대한(유저의) 상세 정보입니다.",


### PR DESCRIPTION
# TL;DR
<!--
작업 내용을 요약해주세요.
-->

# 배경 및 목표
<!--
작업 배경과 작업을 통해 결론적으로 도출되어야 하는 결과를 적어주세요.

예시: 현재는 풀 리퀘스트에 리뷰어가 자동으로 등록되지 않아 불편함이 있습니다. 이젠 PR을 열었을 때 자동으로 3명 이상의 리뷰어가 걸리도록 기능을 추가합니다. (후략)
예시: 인벤토리의 아이템 Hover 기능을 추가합니다. 마우스로 인벤토리의 아이템을 호버했을때 --- 한 요소들이 보이도록 합니다. (후략)
-->
- 특정 유저와 관련된 던전 정보 READ 기능을 추가했습니다.
- 그리고 던전에 대한 Static한 데이터도 추가했습니다.

# 작업 사항
<!--
작업 사항을 List나 Todo로 작성해주세요.
그리고 변경 사항에 대한 UI에 대해 상세히 기술하거나, 사진 혹은 Gif를 업로드 해주세요.

예시: - ... 기능 추가 - ... 한 배경에서 ... 하도록 기능 수정 (후략)
-->
![image](https://github.com/not-blond-beard/Savor-22b/assets/56328777/791936bd-fddc-4035-922f-a4bb53bec203)

